### PR TITLE
support for user registration and authentication with ORCiD

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@ tags
 
 # Configuration
 config/database.yml
+.env
+
+# Ignore RubyMine config files
+.idea

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ rvm:
 
 before_script:
   - psql -c 'create database travis_ci_test;' -U postgres
-  - cp config/database.yml.travis spec/dummy/config/database.yml
+  - cp config/database.yml.travis config/database.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: ruby
+
+rvm:
+  - 2.2.0
+
+before_script:
+  - psql -c 'create database travis_ci_test;' -U postgres
+  - cp config/database.yml.travis spec/dummy/config/database.yml

--- a/Gemfile
+++ b/Gemfile
@@ -15,8 +15,12 @@ gem 'uglifier', '>= 1.3.0'
 gem 'coffee-rails', '~> 4.0.0'
 gem 'jquery-rails'
 
+gem 'dotenv-rails'
+
 gem 'devise', '~> 3.4.0'
 gem 'omniauth'
+gem 'omniauth-orcid'
+gem 'nokogiri'
 
 # bundle exec rake doc:rails generates the API under doc/api.
 # gem 'sdoc', '~> 0.4.0',          group: :doc

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,6 +71,9 @@ GEM
       thread_safe (~> 0.1)
       warden (~> 1.2.3)
     diff-lcs (1.2.5)
+    dotenv (1.0.2)
+    dotenv-rails (1.0.2)
+      dotenv (= 1.0.2)
     erubis (2.7.0)
     execjs (2.3.0)
     factory_girl (4.3.0)
@@ -78,6 +81,8 @@ GEM
     factory_girl_rails (4.3.0)
       factory_girl (~> 4.3.0)
       railties (>= 3.0.0)
+    faraday (0.9.1)
+      multipart-post (>= 1.2, < 3)
     ffaker (1.32.1)
     font-awesome-sass (4.3.1)
       sass (~> 3.2)
@@ -104,6 +109,7 @@ GEM
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     json (1.8.2)
+    jwt (1.2.1)
     loofah (2.0.1)
       nokogiri (>= 1.5.9)
     mail (2.6.3)
@@ -113,11 +119,27 @@ GEM
     mini_portile (0.6.2)
     minitest (5.5.1)
     multi_json (1.10.1)
+    multi_xml (0.5.5)
+    multipart-post (2.0.0)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
+    oauth2 (1.0.0)
+      faraday (>= 0.8, < 0.10)
+      jwt (~> 1.0)
+      multi_json (~> 1.3)
+      multi_xml (~> 0.5)
+      rack (~> 1.2)
     omniauth (1.2.2)
       hashie (>= 1.2, < 4)
       rack (~> 1.0)
+    omniauth-oauth2 (1.2.0)
+      faraday (>= 0.8, < 0.10)
+      multi_json (~> 1.3)
+      oauth2 (~> 1.0)
+      omniauth (~> 1.2)
+    omniauth-orcid (0.6)
+      omniauth (~> 1.0)
+      omniauth-oauth2 (~> 1.1)
     orm_adapter (0.5.0)
     pg (0.18.1)
     pry (0.10.1)
@@ -222,12 +244,15 @@ DEPENDENCIES
   bootstrap-sass (~> 3.3.3)
   coffee-rails (~> 4.0.0)
   devise (~> 3.4.0)
+  dotenv-rails
   factory_girl_rails
   ffaker
   font-awesome-sass (~> 4.3.1)
   haml-rails
   jquery-rails
+  nokogiri
   omniauth
+  omniauth-orcid
   pg
   pry
   pry-doc

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,4 +4,10 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
   def index; end
+
+  # Required by devise/omniauth when not using :database_authenticatable
+  # NOTE: remove if :database_authenticatable is switched ON
+  def new_session_path(scope)
+    root_path
+  end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,0 +1,25 @@
+class SessionsController < Devise::OmniauthCallbacksController
+  def orcid
+    extra_info = OrcidClient.get_user_data(auth_hash['uid'])
+    if extra_info && extra_info[:status] == :ok
+      auth_hash[:full_name] = extra_info[:full_name]
+    else
+      flash[:alert] = extra_info[:message] if extra_info
+    end
+    @user = User.find_or_create_from_auth_hash(auth_hash)
+    if @user.persisted?
+      sign_in_and_redirect(@user, event: :authentication)
+      set_flash_message(:notice, :success, kind: 'ORCiD')
+    end
+  end
+
+  def after_omniauth_failure_path_for(scope)
+    root_path
+  end
+
+  protected
+
+  def auth_hash
+    request.env['omniauth.auth']
+  end
+end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -17,6 +17,12 @@ class SessionsController < Devise::OmniauthCallbacksController
     root_path
   end
 
+  def destroy
+    signed_out = sign_out
+    set_flash_message(:notice, :signed_out) if signed_out
+    redirect_to root_path
+  end
+
   protected
 
   def auth_hash

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,9 +4,17 @@ class User < ActiveRecord::Base
   # devise :database_authenticatable, :registerable,
   #        :recoverable, :rememberable, :trackable, :validatable
 
-  devise :omniauthable, :trackable, :timeoutable
+  devise :omniauthable, :trackable, :timeoutable,
+         omniauth_providers: [:orcid]
 
   include Nondestroyable
 
   validates :login, presence: true, uniqueness: { case_sensitive: false }
+
+  def self.find_or_create_from_auth_hash(auth_hash)
+    user = self.find_or_initialize_by(login: auth_hash['uid'])
+    user.full_name = auth_hash['full_name'] if auth_hash['full_name']
+    user.save
+    user
+  end
 end

--- a/app/services/orcid_client.rb
+++ b/app/services/orcid_client.rb
@@ -1,0 +1,24 @@
+# Service to implement ORCiD client API
+# Currently it simply retrieves user's public info from ORCiD
+class OrcidClient
+  def self.get_user_data(uid)
+    orcid_config = Rails.application.config_for(:orcid)
+    begin
+      uri = URI(orcid_config['client_options']['site'] + '/' + uid)
+      info_xml = Nokogiri::XML(Net::HTTP.get(uri))
+      error_desc = info_xml.at_css('error-desc')
+      raise Exception.new(error_desc.content) if error_desc
+    rescue Exception => e
+      message = "Problem accessing public ORCiD API for uid #{uid}."
+      message += " Reason: \"#{e.message}\"."
+      message += ' No public user information available for the moment.'
+      Rails.logger.warn "WARNING: #{message}"
+      return { status: :error, message: message }
+    end
+    given_names = info_xml.at_css('given-names')
+    full_name = given_names ? given_names.content : ''
+    family_name = info_xml.at_css('family-name')
+    full_name += ' ' + family_name.content if family_name
+    { status: :ok, full_name: full_name }
+  end
+end

--- a/app/views/application/index.html.haml
+++ b/app/views/application/index.html.haml
@@ -1,5 +1,7 @@
 Welcome!
+
 - if user_signed_in?
   = current_user.full_name
-
-= link_to 'Sign in with ORCiD', user_omniauth_authorize_path(:orcid)
+  = link_to 'Sign out', sign_out_path
+- else
+  = link_to 'Sign in with ORCiD', user_omniauth_authorize_path(:orcid)

--- a/app/views/application/index.html.haml
+++ b/app/views/application/index.html.haml
@@ -1,1 +1,5 @@
 Welcome!
+- if user_signed_in?
+  = current_user.full_name
+
+= link_to 'Sign in with ORCiD', user_omniauth_authorize_path(:orcid)

--- a/config/database.yml.travis
+++ b/config/database.yml.travis
@@ -1,0 +1,4 @@
+test:
+  adapter: postgresql
+  database: travis_ci_test
+  username: postgres

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,0 +1,7 @@
+Rails.application.config.middleware.use OmniAuth::Builder do
+  provider :developer unless Rails.env.production?
+  provider :orcid,
+           Rails.application.secrets.orcid_key,
+           Rails.application.secrets.orcid_secret,
+           Rails.application.config_for(:orcid)
+end

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -23,9 +23,6 @@ en:
         subject: "Reset password instructions"
       unlock_instructions:
         subject: "Unlock Instructions"
-    omniauth_callbacks:
-      failure: "Could not authenticate you from %{kind} because \"%{reason}\"."
-      success: "Successfully authenticated from %{kind} account."
     passwords:
       no_token: "You can't access this page without coming from a password reset email. If you do come from a password reset email, please make sure you used the full URL provided."
       send_instructions: "You will receive an email with instructions on how to reset your password in a few minutes."
@@ -43,6 +40,9 @@ en:
     sessions:
       signed_in: "Signed in successfully."
       signed_out: "Signed out successfully."
+      user:
+        failure: "Could not authenticate you from %{kind}. Reason: \"%{reason}\"."
+        success: "Successfully authenticated from %{kind} account."
     unlocks:
       send_instructions: "You will receive an email with instructions about how to unlock your account in a few minutes."
       send_paranoid_instructions: "If your account exists, you will receive an email with instructions about how to unlock it in a few minutes."

--- a/config/orcid.yml
+++ b/config/orcid.yml
@@ -1,0 +1,25 @@
+default: &default
+  authorize_params:
+    scope: /authenticate
+  client_options:
+    site: http://pub.orcid.org
+    authorize_url: http://orcid.org/oauth/authorize
+    token_url: https://pub.orcid.org/oauth/token
+
+sandbox: &sandbox
+  authorize_params:
+    scope: /authenticate
+  client_options:
+    site: http://sandbox.orcid.org
+    authorize_url: http://sandbox.orcid.org/oauth/authorize
+    token_url: https://sandbox.orcid.org/oauth/token
+
+development:
+  <<: *default
+
+test:
+#  <<: *sandbox
+  <<: *default
+
+production:
+  <<: *default

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,9 @@ Rails.application.routes.draw do
                omniauth_callbacks: 'sessions'
              }
 
+  devise_scope :user do
+    get 'sign_out', to: 'sessions#destroy'
+  end
+
   root 'application#index'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,8 @@
 Rails.application.routes.draw do
-  devise_for :users
+  devise_for :users,
+             controllers: {
+               omniauth_callbacks: 'sessions'
+             }
 
   root 'application#index'
 end

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -13,13 +13,19 @@
 development:
   secret_key_base: 146b411db92206e05af4c02dcb0ac77db0925dff83ca4ecef8434aa8b8ed381203ae3c4cd809d684ec9a9108054b0a1621b9f409c6babf904e0f876a129f56c8
   devise_secret_key: 2cb5fde01129a9598d708352b78d62b5a7a7ac96de19776e1b963b9a6b727684539aae763b59ed84c5ea7e3e62a05a35da97c817cc79e8bcf605d6364b27d220
+  orcid_key: <%= ENV["ORCID_KEY"] %>
+  orcid_secret: <%= ENV["ORCID_SECRET"] %>
 
 test:
   secret_key_base: dc681d4add36415b18f7b6b4437622f306beee43009105c8ddc98ca88729a939d866bbc78923b454749f9999b4df07ad6d71c566395cb38f4c1179ff6965b31b
   devise_secret_key: b5b4d61cbb62a63cd2d5f3ef7c22811a5d54ba8f51a9ad9e1a790368e73f3d2244d72ed3d0e777cf9cbce3372ffb9694896dbbd5152709979aa5779031ba914e
+  orcid_key: <%= ENV["ORCID_KEY"] %>
+  orcid_secret: <%= ENV["ORCID_SECRET"] %>
 
 # Do not keep production secrets in the repository,
 # instead read values from the environment.
 production:
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
   devise_secret_key: <%= ENV["DEVISE_SECRET_KEY_BASE"] %>
+  orcid_key: <%= ENV["ORCID_KEY"] %>
+  orcid_secret: <%= ENV["ORCID_SECRET"] %>

--- a/spec/services/orcid_client_spec.rb
+++ b/spec/services/orcid_client_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe OrcidClient do
+  describe '#get_user_data' do
+    it 'loads user full_name from orcid' do
+      extra_info = OrcidClient.get_user_data ENV['ORCID_TEST_UID']
+      expect(extra_info).not_to eq nil
+      expect(extra_info[:status]).to eq :ok
+      expect(extra_info[:full_name]).to eq ENV['ORCID_TEST_FULL_NAME']
+    end
+
+    it 'generates warning but goes on when wrong orcid id' do
+      extra_info = OrcidClient.get_user_data 'error-0000-0002-3822-5163'
+      expect(extra_info).not_to eq nil
+      expect(extra_info[:status]).to eq :error
+      expect(extra_info[:message]).
+        to include 'Problem accessing public ORCiD API for uid'
+    end
+  end
+end


### PR DESCRIPTION
Fixes #1 

A lot of stuff here. Some comments:
 - using omniauth with orcid strategy to auth a user
 - sessions_controller set to do the auth (as a OAuth callback)
 - orcid_client service added to use ORCiD Public API to retrieve user's info based on her/his uid
 - parsing that output is the reason I use nokogiri
 - orcid.yml provides all public orcid config (I may switch testing env config to orcid sandbox after they verify my email there - there are some serious emailing problems with their email verification - but it's ok as it is even now)
 - user is persisted on successful orcid callback even if further user's info retrieval was a failure
