### PR TITLE
CropStore schema migration fix

### DIFF
--- a/app/models/plant_accession.rb
+++ b/app/models/plant_accession.rb
@@ -1,4 +1,5 @@
 class PlantAccession < ActiveRecord::Base
+  self.primary_key = 'plant_accession'
 
   belongs_to :plant_line, foreign_key: 'plant_line_name'
 

--- a/app/models/plant_line.rb
+++ b/app/models/plant_line.rb
@@ -1,4 +1,5 @@
 class PlantLine < ActiveRecord::Base
+  self.primary_key = 'plant_line_name'
 
   belongs_to :plant_variety, foreign_key: 'plant_variety_name'
 

--- a/app/models/plant_population.rb
+++ b/app/models/plant_population.rb
@@ -12,8 +12,8 @@ class PlantPopulation < ActiveRecord::Base
 
   has_and_belongs_to_many :plant_lines,
                           join_table: 'plant_population_lists',
+                          foreign_key: 'plant_population_id',
                           association_foreign_key: 'plant_line_name'
-
 
   # Exlude the ['none', 'unspecified', 'not applicable'] pseudo-record trio
   scope :drop_dummies, -> do

--- a/app/models/plant_variety.rb
+++ b/app/models/plant_variety.rb
@@ -1,4 +1,5 @@
 class PlantVariety < ActiveRecord::Base
+  self.primary_key = 'plant_variety_name'
 
   has_many :plant_variety_details, foreign_key: 'plant_variety_name'
   has_many :plant_lines, foreign_key: 'plant_variety_name'

--- a/app/models/plant_variety_detail.rb
+++ b/app/models/plant_variety_detail.rb
@@ -1,5 +1,6 @@
 class PlantVarietyDetail < ActiveRecord::Base
   self.table_name = 'plant_variety_detail'
+  self.primary_key = 'plant_variety_name'
 
   belongs_to :plant_variety, foreign_key: 'plant_variety_name'
 

--- a/app/models/population_type_lookup.rb
+++ b/app/models/population_type_lookup.rb
@@ -1,5 +1,6 @@
 class PopulationTypeLookup < ActiveRecord::Base
   self.table_name = 'pop_type_lookup'
+  self.primary_key = 'population_type'
 
   has_many :plant_populations, foreign_key: 'population_type'
 

--- a/db/migrate/20150212100000_import_cropstore_db.rb
+++ b/db/migrate/20150212100000_import_cropstore_db.rb
@@ -316,7 +316,8 @@ class ImportCropstoreDb < ActiveRecord::Migration
       add_index "map_positions", ["map_position"], name: "idx_143597_map_position", using: :btree
       add_index "map_positions", ["mapping_locus"], name: "idx_143597_mapping_locus", using: :btree
 
-      create_table "marker_assays", primary_key: "marker_assay_name", force: :cascade do |t|
+      create_table "marker_assays", id: false, force: :cascade do |t|
+        t.text "marker_assay_name",          primary: true
         t.text "canonical_marker_name",      default: "unspecified", null: false
         t.text "marker_type",                default: "unspecified", null: false
         t.text "probe_name",                 default: "unspecified", null: false
@@ -336,7 +337,8 @@ class ImportCropstoreDb < ActiveRecord::Migration
         t.text "confirmed_by_whom",          default: "unspecified", null: false
       end
 
-      create_table "marker_sequence_assignments", primary_key: "canonical_marker_name", force: :cascade do |t|
+      create_table "marker_sequence_assignments", id: false, force: :cascade do |t|
+        t.text "canonical_marker_name",   primary: true
         t.text "marker_set",              default: "unspecified", null: false
         t.text "associated_sequence_id",  default: "unspecified", null: false
         t.text "sequence_source_acronym", default: "unspecified", null: false
@@ -352,7 +354,8 @@ class ImportCropstoreDb < ActiveRecord::Migration
 
       add_index "marker_sequence_assignments", ["canonical_marker_name"], name: "idx_143632_canonical_marker_name", using: :btree
 
-      create_table "marker_sequence_hits", primary_key: "canonical_marker_name", force: :cascade do |t|
+      create_table "marker_sequence_hits", id: false, force: :cascade do |t|
+        t.text "canonical_marker_name",       primary: true
         t.text "target_collection_id",        default: "unspecified", null: false
         t.text "hit_rank_number",             default: "unspecified", null: false
         t.text "target_hit_id",               default: "unspecified", null: false
@@ -367,7 +370,8 @@ class ImportCropstoreDb < ActiveRecord::Migration
         t.text "confirmed_by_whom",           default: "unspecified", null: false
       end
 
-      create_table "marker_variations", primary_key: "marker_variation", force: :cascade do |t|
+      create_table "marker_variations", id: false, force: :cascade do |t|
+        t.text "marker_variation",  primary: true
         t.text "marker_assay_name", default: "unspecified", null: false
         t.text "description",                               null: false
         t.text "described_by_whom", default: "unspecified", null: false
@@ -399,7 +403,8 @@ class ImportCropstoreDb < ActiveRecord::Migration
         t.text "confirmed_by_whom", default: "unspecified", null: false
       end
 
-      create_table "plant_accessions", primary_key: "plant_accession", force: :cascade do |t|
+      create_table "plant_accessions", id: false, force: :cascade do |t|
+        t.text "plant_accession",            primary: true
         t.text "plant_line_name",            default: "unspecified", null: false
         t.text "plant_accession_derivation", default: "unspecified", null: false
         t.text "accession_originator",       default: "unspecified", null: false
@@ -444,7 +449,8 @@ class ImportCropstoreDb < ActiveRecord::Migration
       add_index "plant_individuals", ["plant_trial_id"], name: "idx_143711_trial", using: :btree
       add_index "plant_individuals", ["row_plot_position_id"], name: "idx_143711_row_plot_position", using: :btree
 
-      create_table "plant_line_assigned_genotypes", primary_key: "plant_line_name", force: :cascade do |t|
+      create_table "plant_line_assigned_genotypes", id: false, force: :cascade do |t|
+        t.text "plant_line_name",       primary: true
         t.text "plant_population",      default: "unspecified", null: false
         t.text "mapping_locus",         default: "unspecified", null: false
         t.text "zygote_locus_genotype", default: "unspecified", null: false
@@ -463,7 +469,8 @@ class ImportCropstoreDb < ActiveRecord::Migration
       add_index "plant_line_assigned_genotypes", ["plant_line_name"], name: "idx_143749_plant_line", using: :btree
       add_index "plant_line_assigned_genotypes", ["plant_population", "mapping_locus", "zygote_locus_genotype"], name: "idx_143749_fk_plant_line_assigned_genotypes_1", using: :btree
 
-      create_table "plant_lines", primary_key: "plant_line_name", force: :cascade do |t|
+      create_table "plant_lines", id: false, force: :cascade do |t|
+        t.text "plant_line_name",    primary: true
         t.text "genus",              default: "unspecified", null: false
         t.text "species",            default: "unspecified", null: false
         t.text "subtaxa",            default: "unspecified", null: false
@@ -522,7 +529,8 @@ class ImportCropstoreDb < ActiveRecord::Migration
       add_index "plant_marker_variations", ["marker_variation"], name: "idx_143781_marker_variation", using: :btree
       add_index "plant_marker_variations", ["occasion"], name: "idx_143781_occasion", using: :btree
 
-      create_table "plant_parts", primary_key: "plant_part", force: :cascade do |t|
+      create_table "plant_parts", id: false, force: :cascade do |t|
+        t.text "plant_part",        primary: true
         t.text "description",                               null: false
         t.text "described_by_whom", default: "unspecified", null: false
         t.text "comments",                                  null: false
@@ -642,25 +650,27 @@ class ImportCropstoreDb < ActiveRecord::Migration
         t.text   "confirmed_by_whom",                  default: "unspecified", null: false
       end
 
-      create_table "plant_varieties", primary_key: "plant_variety_name", force: :cascade do |t|
-        t.text "genus",             default: "unspecified", null: false
-        t.text "species",           default: "unspecified", null: false
-        t.text "subtaxa",           default: "unspecified", null: false
-        t.text "taxa_authority",    default: "unspecified", null: false
-        t.text "subtaxa_authority", default: "unspecified", null: false
-        t.text "crop_type",         default: "unspecified", null: false
-        t.text "comments",                                  null: false
-        t.text "entered_by_whom",   default: "unspecified", null: false
+      create_table "plant_varieties", id: false, force: :cascade do |t|
+        t.text "plant_variety_name", primary: true
+        t.text "genus",              default: "unspecified", null: false
+        t.text "species",            default: "unspecified", null: false
+        t.text "subtaxa",            default: "unspecified", null: false
+        t.text "taxa_authority" ,    default: "unspecified", null: false
+        t.text "subtaxa_authority",  default: "unspecified", null: false
+        t.text "crop_type",          default: "unspecified", null: false
+        t.text "comments",                                   null: false
+        t.text "entered_by_whom",    default: "unspecified", null: false
         t.date "date_entered"
-        t.text "data_provenance",                           null: false
-        t.text "data_owned_by",     default: "unspecified", null: false
-        t.text "data_status",       default: "unspecified", null: false
-        t.text "confirmed_by_whom", default: "unspecified", null: false
+        t.text "data_provenance",                            null: false
+        t.text "data_owned_by",      default: "unspecified", null: false
+        t.text "data_status",        default: "unspecified", null: false
+        t.text "confirmed_by_whom",  default: "unspecified", null: false
       end
 
       add_index "plant_varieties", ["plant_variety_name"], name: "idx_143909_plant_variety_name", using: :btree
 
-      create_table "plant_variety_detail", primary_key: "plant_variety_name", force: :cascade do |t|
+      create_table "plant_variety_detail", id: false, force: :cascade do |t|
+        t.text "plant_variety_name",    primary: true
         t.text "data_attribution",      default: "unspecified", null: false
         t.text "country_of_origin",     default: "xxx",         null: false
         t.text "country_registered",    default: "xxx",         null: false
@@ -709,12 +719,14 @@ class ImportCropstoreDb < ActiveRecord::Migration
       add_index "pop_locus_genotype_alleles", ["plant_population", "mapping_locus", "locus_genotype", "allele_number"], name: "idx_143991_fk_population_locus_genotype_alleles_2", using: :btree
       add_index "pop_locus_genotype_alleles", ["plant_population"], name: "idx_143991_plant_population", using: :btree
 
-      create_table "pop_type_lookup", primary_key: "population_type", force: :cascade do |t|
+      create_table "pop_type_lookup", id: false, force: :cascade do |t|
+        t.text "population_type",  primary: true
         t.text "population_class", default: "unspecified", null: false
         t.text "assigned_by_whom", default: "unspecified", null: false
       end
 
-      create_table "population_genotypes", primary_key: "plant_population", force: :cascade do |t|
+      create_table "population_genotypes", id: false, force: :cascade do |t|
+        t.text "plant_population",      primary: true
         t.text "mapping_locus",         default: "unspecified", null: false
         t.text "zygote_locus_genotype", default: "unspecified", null: false
         t.text "locus_code_system",     default: "unspecified", null: false
@@ -731,7 +743,8 @@ class ImportCropstoreDb < ActiveRecord::Migration
       add_index "population_genotypes", ["plant_population"], name: "idx_143947_plant_population", using: :btree
       add_index "population_genotypes", ["zygote_locus_genotype"], name: "idx_143947_genotype", using: :btree
 
-      create_table "population_loci", primary_key: "mapping_locus", force: :cascade do |t|
+      create_table "population_loci", id: false, force: :cascade do |t|
+        t.text "mapping_locus",     primary: true
         t.text "plant_population",  default: "unspecified", null: false
         t.text "marker_assay_name", default: "unspecified", null: false
         t.text "defined_by_whom",   default: "unspecified", null: false
@@ -748,7 +761,8 @@ class ImportCropstoreDb < ActiveRecord::Migration
       add_index "population_loci", ["marker_assay_name"], name: "idx_143961_marker_assay", using: :btree
       add_index "population_loci", ["plant_population"], name: "idx_143961_plant_population", using: :btree
 
-      create_table "population_locus_alleles", primary_key: "plant_population", force: :cascade do |t|
+      create_table "population_locus_alleles", id: false, force: :cascade do |t|
+        t.text "plant_population",     primary: true
         t.text "mapping_locus",        default: "unspecified", null: false
         t.text "gametic_locus_allele", default: "unspecified", null: false
         t.text "marker_variation",     default: "unspecified", null: false
@@ -769,7 +783,8 @@ class ImportCropstoreDb < ActiveRecord::Migration
       add_index "population_locus_alleles", ["marker_variation"], name: "idx_143975_marker_variation", using: :btree
       add_index "population_locus_alleles", ["plant_population"], name: "idx_143975_plant_population", using: :btree
 
-      create_table "primers", primary_key: "primer", force: :cascade do |t|
+      create_table "primers", id: false, force: :cascade do |t|
+        t.text "primer",                    primary: true
         t.text "sequence",                  default: "unspecified", null: false
         t.text "sequence_id",               default: "unspecified", null: false
         t.text "sequence_source_acronym",   default: "unspecified", null: false
@@ -896,7 +911,8 @@ class ImportCropstoreDb < ActiveRecord::Migration
       add_index "qtl_jobs", ["linkage_map_id"], name: "idx_144140_linkage_map_id", using: :btree
       add_index "qtl_jobs", ["qtl_software", "qtl_method"], name: "idx_144140_qtl_software", using: :btree
 
-      create_table "restriction_enzymes", primary_key: "restriction_enzyme", force: :cascade do |t|
+      create_table "restriction_enzymes", id: false, force: :cascade do |t|
+        t.text "restriction_enzyme",                       primary: true
         t.text "recognition_site", default: "unspecified", null: false
         t.text "data_provenance",                          null: false
       end
@@ -999,7 +1015,8 @@ class ImportCropstoreDb < ActiveRecord::Migration
       add_index "trait_scores", ["scoring_occasion_id"], name: "idx_144229_scoring_occasion", using: :btree
       add_index "trait_scores", ["trait_descriptor_id"], name: "idx_144229_trait_descriptor", using: :btree
 
-      create_table "version", primary_key: "version", force: :cascade do |t|
+      create_table "version", id: false, force: :cascade do |t|
+        t.text "version",         primary: true
         t.date "date"
         t.text "updated_by_whom", default: "unspecified", null: false
         t.text "comments",                                null: false
@@ -1012,7 +1029,8 @@ class ImportCropstoreDb < ActiveRecord::Migration
       # These are extensions that must be enabled in order to support this database
       enable_extension "plpgsql"
 
-      create_table "clone_libraries", primary_key: "library_name", force: :cascade do |t|
+      create_table "clone_libraries", id: false, force: :cascade do |t|
+        t.text "library_name",                primary: true
         t.text "library_type",                default: "unspecified", null: false
         t.text "genus",                       default: "unspecified", null: false
         t.text "species",                     default: "unspecified", null: false
@@ -1053,7 +1071,8 @@ class ImportCropstoreDb < ActiveRecord::Migration
       add_index "clone_libraries", ["plant_accession"], name: "idx_143333_fk_clone_libraries_1", using: :btree
       add_index "clone_libraries", ["species"], name: "idx_143333_species", using: :btree
 
-      create_table "clones", primary_key: "clone_name", force: :cascade do |t|
+      create_table "clones", id: false, force: :cascade do |t|
+        t.text "clone_name",              primary: true
         t.text "library_name",            default: "unspecified", null: false
         t.text "clone_type",              default: "unspecified", null: false
         t.text "gene",                    default: "unspecified", null: false
@@ -1078,13 +1097,15 @@ class ImportCropstoreDb < ActiveRecord::Migration
       add_index "clones", ["clone_type"], name: "idx_143312_clone_type", using: :btree
       add_index "clones", ["library_name"], name: "idx_143312_fk_clones_1", using: :btree
 
-      create_table "countries", primary_key: "country_code", force: :cascade do |t|
+      create_table "countries", id: false, force: :cascade do |t|
+        t.text "country_code",    primary: true
         t.text "country_name",    default: "unspecified", null: false
         t.text "data_provenance",                         null: false
         t.text "comments",                                null: false
       end
 
-      create_table "cs_additional_information", primary_key: "table_name", force: :cascade do |t|
+      create_table "cs_additional_information", id: false, force: :cascade do |t|
+        t.text "table_name",             primary: true
         t.text "single_key_field",       default: "unspecified", null: false
         t.text "key_value",              default: "unspecified", null: false
         t.text "additional_count",       default: "unspecified", null: false
@@ -1323,7 +1344,8 @@ class ImportCropstoreDb < ActiveRecord::Migration
       add_index "map_positions", ["map_position"], name: "idx_143597_map_position", using: :btree
       add_index "map_positions", ["mapping_locus"], name: "idx_143597_mapping_locus", using: :btree
 
-      create_table "marker_assays", primary_key: "marker_assay_name", force: :cascade do |t|
+      create_table "marker_assays", id: false, force: :cascade do |t|
+        t.text "marker_assay_name",          primary: true
         t.text "canonical_marker_name",      default: "unspecified", null: false
         t.text "marker_type",                default: "unspecified", null: false
         t.text "probe_name",                 default: "unspecified", null: false
@@ -1343,7 +1365,8 @@ class ImportCropstoreDb < ActiveRecord::Migration
         t.text "confirmed_by_whom",          default: "unspecified", null: false
       end
 
-      create_table "marker_sequence_assignments", primary_key: "canonical_marker_name", force: :cascade do |t|
+      create_table "marker_sequence_assignments", id: false, force: :cascade do |t|
+        t.text "canonical_marker_name",   primary: true
         t.text "marker_set",              default: "unspecified", null: false
         t.text "associated_sequence_id",  default: "unspecified", null: false
         t.text "sequence_source_acronym", default: "unspecified", null: false
@@ -1359,7 +1382,8 @@ class ImportCropstoreDb < ActiveRecord::Migration
 
       add_index "marker_sequence_assignments", ["canonical_marker_name"], name: "idx_143632_canonical_marker_name", using: :btree
 
-      create_table "marker_sequence_hits", primary_key: "canonical_marker_name", force: :cascade do |t|
+      create_table "marker_sequence_hits", id: false, force: :cascade do |t|
+        t.text "canonical_marker_name",       primary: true
         t.text "target_collection_id",        default: "unspecified", null: false
         t.text "hit_rank_number",             default: "unspecified", null: false
         t.text "target_hit_id",               default: "unspecified", null: false
@@ -1374,7 +1398,8 @@ class ImportCropstoreDb < ActiveRecord::Migration
         t.text "confirmed_by_whom",           default: "unspecified", null: false
       end
 
-      create_table "marker_variations", primary_key: "marker_variation", force: :cascade do |t|
+      create_table "marker_variations", id: false, force: :cascade do |t|
+        t.text "marker_variation",  primary: true
         t.text "marker_assay_name", default: "unspecified", null: false
         t.text "description",                               null: false
         t.text "described_by_whom", default: "unspecified", null: false
@@ -1406,7 +1431,8 @@ class ImportCropstoreDb < ActiveRecord::Migration
         t.text "confirmed_by_whom", default: "unspecified", null: false
       end
 
-      create_table "plant_accessions", primary_key: "plant_accession", force: :cascade do |t|
+      create_table "plant_accessions", id: false, force: :cascade do |t|
+        t.text "plant_accession",            primary: true
         t.text "plant_line_name",            default: "unspecified", null: false
         t.text "plant_accession_derivation", default: "unspecified", null: false
         t.text "accession_originator",       default: "unspecified", null: false
@@ -1451,7 +1477,8 @@ class ImportCropstoreDb < ActiveRecord::Migration
       add_index "plant_individuals", ["plant_trial_id"], name: "idx_143711_trial", using: :btree
       add_index "plant_individuals", ["row_plot_position_id"], name: "idx_143711_row_plot_position", using: :btree
 
-      create_table "plant_line_assigned_genotypes", primary_key: "plant_line_name", force: :cascade do |t|
+      create_table "plant_line_assigned_genotypes", id: false, force: :cascade do |t|
+        t.text "plant_line_name",       primary: true
         t.text "plant_population",      default: "unspecified", null: false
         t.text "mapping_locus",         default: "unspecified", null: false
         t.text "zygote_locus_genotype", default: "unspecified", null: false
@@ -1470,7 +1497,8 @@ class ImportCropstoreDb < ActiveRecord::Migration
       add_index "plant_line_assigned_genotypes", ["plant_line_name"], name: "idx_143749_plant_line", using: :btree
       add_index "plant_line_assigned_genotypes", ["plant_population", "mapping_locus", "zygote_locus_genotype"], name: "idx_143749_fk_plant_line_assigned_genotypes_1", using: :btree
 
-      create_table "plant_lines", primary_key: "plant_line_name", force: :cascade do |t|
+      create_table "plant_lines", id: false, force: :cascade do |t|
+        t.text "plant_line_name",    primary: true
         t.text "genus",              default: "unspecified", null: false
         t.text "species",            default: "unspecified", null: false
         t.text "subtaxa",            default: "unspecified", null: false
@@ -1529,7 +1557,8 @@ class ImportCropstoreDb < ActiveRecord::Migration
       add_index "plant_marker_variations", ["marker_variation"], name: "idx_143781_marker_variation", using: :btree
       add_index "plant_marker_variations", ["occasion"], name: "idx_143781_occasion", using: :btree
 
-      create_table "plant_parts", primary_key: "plant_part", force: :cascade do |t|
+      create_table "plant_parts", id: false, force: :cascade do |t|
+        t.text "plant_part",        primary: true
         t.text "description",                               null: false
         t.text "described_by_whom", default: "unspecified", null: false
         t.text "comments",                                  null: false
@@ -1649,25 +1678,27 @@ class ImportCropstoreDb < ActiveRecord::Migration
         t.text   "confirmed_by_whom",                  default: "unspecified", null: false
       end
 
-      create_table "plant_varieties", primary_key: "plant_variety_name", force: :cascade do |t|
-        t.text "genus",             default: "unspecified", null: false
-        t.text "species",           default: "unspecified", null: false
-        t.text "subtaxa",           default: "unspecified", null: false
-        t.text "taxa_authority",    default: "unspecified", null: false
-        t.text "subtaxa_authority", default: "unspecified", null: false
-        t.text "crop_type",         default: "unspecified", null: false
-        t.text "comments",                                  null: false
-        t.text "entered_by_whom",   default: "unspecified", null: false
+      create_table "plant_varieties", id: false, force: :cascade do |t|
+        t.text "plant_variety_name", primary: true
+        t.text "genus",              default: "unspecified", null: false
+        t.text "species",            default: "unspecified", null: false
+        t.text "subtaxa",            default: "unspecified", null: false
+        t.text "taxa_authority",     default: "unspecified", null: false
+        t.text "subtaxa_authority",  default: "unspecified", null: false
+        t.text "crop_type",          default: "unspecified", null: false
+        t.text "comments",                                   null: false
+        t.text "entered_by_whom",    default: "unspecified", null: false
         t.date "date_entered"
-        t.text "data_provenance",                           null: false
-        t.text "data_owned_by",     default: "unspecified", null: false
-        t.text "data_status",       default: "unspecified", null: false
-        t.text "confirmed_by_whom", default: "unspecified", null: false
+        t.text "data_provenance",                            null: false
+        t.text "data_owned_by",      default: "unspecified", null: false
+        t.text "data_status",        default: "unspecified", null: false
+        t.text "confirmed_by_whom",  default: "unspecified", null: false
       end
 
       add_index "plant_varieties", ["plant_variety_name"], name: "idx_143909_plant_variety_name", using: :btree
 
-      create_table "plant_variety_detail", primary_key: "plant_variety_name", force: :cascade do |t|
+      create_table "plant_variety_detail", id: false, force: :cascade do |t|
+        t.text "plant_variety_name",    primary: true
         t.text "data_attribution",      default: "unspecified", null: false
         t.text "country_of_origin",     default: "xxx",         null: false
         t.text "country_registered",    default: "xxx",         null: false
@@ -1691,7 +1722,8 @@ class ImportCropstoreDb < ActiveRecord::Migration
       add_index "plant_variety_detail", ["data_attribution"], name: "idx_143926_data_provenance", using: :btree
       add_index "plant_variety_detail", ["plant_variety_name"], name: "idx_143926_plant_variety_name", using: :btree
 
-      create_table "pop_locus_genotype_alleles", primary_key: "allele_number", force: :cascade do |t|
+      create_table "pop_locus_genotype_alleles", id: false, force: :cascade do |t|
+        t.text "allele_number",        primary: true
         t.text "plant_population",     default: "unspecified", null: false
         t.text "mapping_locus",        default: "unspecified", null: false
         t.text "locus_genotype",       default: "unspecified", null: false
@@ -1716,12 +1748,14 @@ class ImportCropstoreDb < ActiveRecord::Migration
       add_index "pop_locus_genotype_alleles", ["plant_population", "mapping_locus", "locus_genotype", "allele_number"], name: "idx_143991_fk_population_locus_genotype_alleles_2", using: :btree
       add_index "pop_locus_genotype_alleles", ["plant_population"], name: "idx_143991_plant_population", using: :btree
 
-      create_table "pop_type_lookup", primary_key: "population_type", force: :cascade do |t|
+      create_table "pop_type_lookup", id: false, force: :cascade do |t|
+        t.text "population_type",  primary: true
         t.text "population_class", default: "unspecified", null: false
         t.text "assigned_by_whom", default: "unspecified", null: false
       end
 
-      create_table "population_genotypes", primary_key: "plant_population", force: :cascade do |t|
+      create_table "population_genotypes", id: false, force: :cascade do |t|
+        t.text "plant_population",      primary: true
         t.text "mapping_locus",         default: "unspecified", null: false
         t.text "zygote_locus_genotype", default: "unspecified", null: false
         t.text "locus_code_system",     default: "unspecified", null: false
@@ -1738,7 +1772,8 @@ class ImportCropstoreDb < ActiveRecord::Migration
       add_index "population_genotypes", ["plant_population"], name: "idx_143947_plant_population", using: :btree
       add_index "population_genotypes", ["zygote_locus_genotype"], name: "idx_143947_genotype", using: :btree
 
-      create_table "population_loci", primary_key: "mapping_locus", force: :cascade do |t|
+      create_table "population_loci", id: false, force: :cascade do |t|
+        t.text "mapping_locus",     primary: true
         t.text "plant_population",  default: "unspecified", null: false
         t.text "marker_assay_name", default: "unspecified", null: false
         t.text "defined_by_whom",   default: "unspecified", null: false
@@ -1755,7 +1790,8 @@ class ImportCropstoreDb < ActiveRecord::Migration
       add_index "population_loci", ["marker_assay_name"], name: "idx_143961_marker_assay", using: :btree
       add_index "population_loci", ["plant_population"], name: "idx_143961_plant_population", using: :btree
 
-      create_table "population_locus_alleles", primary_key: "plant_population", force: :cascade do |t|
+      create_table "population_locus_alleles", id: false, force: :cascade do |t|
+        t.text "plant_population",     primary: true
         t.text "mapping_locus",        default: "unspecified", null: false
         t.text "gametic_locus_allele", default: "unspecified", null: false
         t.text "marker_variation",     default: "unspecified", null: false
@@ -1776,7 +1812,8 @@ class ImportCropstoreDb < ActiveRecord::Migration
       add_index "population_locus_alleles", ["marker_variation"], name: "idx_143975_marker_variation", using: :btree
       add_index "population_locus_alleles", ["plant_population"], name: "idx_143975_plant_population", using: :btree
 
-      create_table "primers", primary_key: "primer", force: :cascade do |t|
+      create_table "primers", id: false, force: :cascade do |t|
+        t.text "primer",                    primary: true
         t.text "sequence",                  default: "unspecified", null: false
         t.text "sequence_id",               default: "unspecified", null: false
         t.text "sequence_source_acronym",   default: "unspecified", null: false
@@ -1903,7 +1940,8 @@ class ImportCropstoreDb < ActiveRecord::Migration
       add_index "qtl_jobs", ["linkage_map_id"], name: "idx_144140_linkage_map_id", using: :btree
       add_index "qtl_jobs", ["qtl_software", "qtl_method"], name: "idx_144140_qtl_software", using: :btree
 
-      create_table "restriction_enzymes", primary_key: "restriction_enzyme", force: :cascade do |t|
+      create_table "restriction_enzymes", id: false, force: :cascade do |t|
+        t.text "restriction_enzyme",                       primary: true
         t.text "recognition_site", default: "unspecified", null: false
         t.text "data_provenance",                          null: false
       end
@@ -2006,7 +2044,8 @@ class ImportCropstoreDb < ActiveRecord::Migration
       add_index "trait_scores", ["scoring_occasion_id"], name: "idx_144229_scoring_occasion", using: :btree
       add_index "trait_scores", ["trait_descriptor_id"], name: "idx_144229_trait_descriptor", using: :btree
 
-      create_table "version", primary_key: "version", force: :cascade do |t|
+      create_table "version", id: false, force: :cascade do |t|
+        t.text "version",         primary: true
         t.date "date"
         t.text "updated_by_whom", default: "unspecified", null: false
         t.text "comments",                                null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -17,7 +17,8 @@ ActiveRecord::Schema.define(version: 20150225145528) do
   enable_extension "plpgsql"
   enable_extension "hstore"
 
-  create_table "clone_libraries", primary_key: "library_name", force: :cascade do |t|
+  create_table "clone_libraries", id: false, force: :cascade do |t|
+    t.text "library_name"
     t.text "library_type",                default: "unspecified", null: false
     t.text "genus",                       default: "unspecified", null: false
     t.text "species",                     default: "unspecified", null: false
@@ -58,7 +59,8 @@ ActiveRecord::Schema.define(version: 20150225145528) do
   add_index "clone_libraries", ["plant_accession"], name: "idx_143333_fk_clone_libraries_1", using: :btree
   add_index "clone_libraries", ["species"], name: "idx_143333_species", using: :btree
 
-  create_table "clones", primary_key: "clone_name", force: :cascade do |t|
+  create_table "clones", id: false, force: :cascade do |t|
+    t.text "clone_name"
     t.text "library_name",            default: "unspecified", null: false
     t.text "clone_type",              default: "unspecified", null: false
     t.text "gene",                    default: "unspecified", null: false
@@ -83,13 +85,15 @@ ActiveRecord::Schema.define(version: 20150225145528) do
   add_index "clones", ["clone_type"], name: "idx_143312_clone_type", using: :btree
   add_index "clones", ["library_name"], name: "idx_143312_fk_clones_1", using: :btree
 
-  create_table "countries", primary_key: "country_code", force: :cascade do |t|
+  create_table "countries", id: false, force: :cascade do |t|
+    t.text "country_code"
     t.text "country_name",    default: "unspecified", null: false
     t.text "data_provenance",                         null: false
     t.text "comments",                                null: false
   end
 
-  create_table "cs_additional_information", primary_key: "table_name", force: :cascade do |t|
+  create_table "cs_additional_information", id: false, force: :cascade do |t|
+    t.text "table_name"
     t.text "single_key_field",       default: "unspecified", null: false
     t.text "key_value",              default: "unspecified", null: false
     t.text "additional_count",       default: "unspecified", null: false
@@ -328,7 +332,8 @@ ActiveRecord::Schema.define(version: 20150225145528) do
   add_index "map_positions", ["map_position"], name: "idx_143597_map_position", using: :btree
   add_index "map_positions", ["mapping_locus"], name: "idx_143597_mapping_locus", using: :btree
 
-  create_table "marker_assays", primary_key: "marker_assay_name", force: :cascade do |t|
+  create_table "marker_assays", id: false, force: :cascade do |t|
+    t.text "marker_assay_name"
     t.text "canonical_marker_name",      default: "unspecified", null: false
     t.text "marker_type",                default: "unspecified", null: false
     t.text "probe_name",                 default: "unspecified", null: false
@@ -348,7 +353,8 @@ ActiveRecord::Schema.define(version: 20150225145528) do
     t.text "confirmed_by_whom",          default: "unspecified", null: false
   end
 
-  create_table "marker_sequence_assignments", primary_key: "canonical_marker_name", force: :cascade do |t|
+  create_table "marker_sequence_assignments", id: false, force: :cascade do |t|
+    t.text "canonical_marker_name"
     t.text "marker_set",              default: "unspecified", null: false
     t.text "associated_sequence_id",  default: "unspecified", null: false
     t.text "sequence_source_acronym", default: "unspecified", null: false
@@ -364,7 +370,8 @@ ActiveRecord::Schema.define(version: 20150225145528) do
 
   add_index "marker_sequence_assignments", ["canonical_marker_name"], name: "idx_143632_canonical_marker_name", using: :btree
 
-  create_table "marker_sequence_hits", primary_key: "canonical_marker_name", force: :cascade do |t|
+  create_table "marker_sequence_hits", id: false, force: :cascade do |t|
+    t.text "canonical_marker_name"
     t.text "target_collection_id",        default: "unspecified", null: false
     t.text "hit_rank_number",             default: "unspecified", null: false
     t.text "target_hit_id",               default: "unspecified", null: false
@@ -379,7 +386,8 @@ ActiveRecord::Schema.define(version: 20150225145528) do
     t.text "confirmed_by_whom",           default: "unspecified", null: false
   end
 
-  create_table "marker_variations", primary_key: "marker_variation", force: :cascade do |t|
+  create_table "marker_variations", id: false, force: :cascade do |t|
+    t.text "marker_variation"
     t.text "marker_assay_name", default: "unspecified", null: false
     t.text "description",                               null: false
     t.text "described_by_whom", default: "unspecified", null: false
@@ -411,7 +419,8 @@ ActiveRecord::Schema.define(version: 20150225145528) do
     t.text "confirmed_by_whom", default: "unspecified", null: false
   end
 
-  create_table "plant_accessions", primary_key: "plant_accession", force: :cascade do |t|
+  create_table "plant_accessions", id: false, force: :cascade do |t|
+    t.text "plant_accession"
     t.text "plant_line_name",            default: "unspecified", null: false
     t.text "plant_accession_derivation", default: "unspecified", null: false
     t.text "accession_originator",       default: "unspecified", null: false
@@ -456,7 +465,8 @@ ActiveRecord::Schema.define(version: 20150225145528) do
   add_index "plant_individuals", ["plant_trial_id"], name: "idx_143711_trial", using: :btree
   add_index "plant_individuals", ["row_plot_position_id"], name: "idx_143711_row_plot_position", using: :btree
 
-  create_table "plant_line_assigned_genotypes", primary_key: "plant_line_name", force: :cascade do |t|
+  create_table "plant_line_assigned_genotypes", id: false, force: :cascade do |t|
+    t.text "plant_line_name"
     t.text "plant_population",      default: "unspecified", null: false
     t.text "mapping_locus",         default: "unspecified", null: false
     t.text "zygote_locus_genotype", default: "unspecified", null: false
@@ -475,7 +485,8 @@ ActiveRecord::Schema.define(version: 20150225145528) do
   add_index "plant_line_assigned_genotypes", ["plant_line_name"], name: "idx_143749_plant_line", using: :btree
   add_index "plant_line_assigned_genotypes", ["plant_population", "mapping_locus", "zygote_locus_genotype"], name: "idx_143749_fk_plant_line_assigned_genotypes_1", using: :btree
 
-  create_table "plant_lines", primary_key: "plant_line_name", force: :cascade do |t|
+  create_table "plant_lines", id: false, force: :cascade do |t|
+    t.text    "plant_line_name"
     t.text    "genus",              default: "unspecified", null: false
     t.text    "species",            default: "unspecified", null: false
     t.text    "subtaxa",            default: "unspecified", null: false
@@ -536,7 +547,8 @@ ActiveRecord::Schema.define(version: 20150225145528) do
   add_index "plant_marker_variations", ["marker_variation"], name: "idx_143781_marker_variation", using: :btree
   add_index "plant_marker_variations", ["occasion"], name: "idx_143781_occasion", using: :btree
 
-  create_table "plant_parts", primary_key: "plant_part", force: :cascade do |t|
+  create_table "plant_parts", id: false, force: :cascade do |t|
+    t.text "plant_part"
     t.text "description",                               null: false
     t.text "described_by_whom", default: "unspecified", null: false
     t.text "comments",                                  null: false
@@ -656,25 +668,27 @@ ActiveRecord::Schema.define(version: 20150225145528) do
     t.text   "confirmed_by_whom",                  default: "unspecified", null: false
   end
 
-  create_table "plant_varieties", primary_key: "plant_variety_name", force: :cascade do |t|
-    t.text "genus",             default: "unspecified", null: false
-    t.text "species",           default: "unspecified", null: false
-    t.text "subtaxa",           default: "unspecified", null: false
-    t.text "taxa_authority",    default: "unspecified", null: false
-    t.text "subtaxa_authority", default: "unspecified", null: false
-    t.text "crop_type",         default: "unspecified", null: false
-    t.text "comments",                                  null: false
-    t.text "entered_by_whom",   default: "unspecified", null: false
+  create_table "plant_varieties", id: false, force: :cascade do |t|
+    t.text "plant_variety_name"
+    t.text "genus",              default: "unspecified", null: false
+    t.text "species",            default: "unspecified", null: false
+    t.text "subtaxa",            default: "unspecified", null: false
+    t.text "taxa_authority",     default: "unspecified", null: false
+    t.text "subtaxa_authority",  default: "unspecified", null: false
+    t.text "crop_type",          default: "unspecified", null: false
+    t.text "comments",                                   null: false
+    t.text "entered_by_whom",    default: "unspecified", null: false
     t.date "date_entered"
-    t.text "data_provenance",                           null: false
-    t.text "data_owned_by",     default: "unspecified", null: false
-    t.text "data_status",       default: "unspecified", null: false
-    t.text "confirmed_by_whom", default: "unspecified", null: false
+    t.text "data_provenance",                            null: false
+    t.text "data_owned_by",      default: "unspecified", null: false
+    t.text "data_status",        default: "unspecified", null: false
+    t.text "confirmed_by_whom",  default: "unspecified", null: false
   end
 
   add_index "plant_varieties", ["plant_variety_name"], name: "idx_143909_plant_variety_name", using: :btree
 
-  create_table "plant_variety_detail", primary_key: "plant_variety_name", force: :cascade do |t|
+  create_table "plant_variety_detail", id: false, force: :cascade do |t|
+    t.text "plant_variety_name"
     t.text "data_attribution",      default: "unspecified", null: false
     t.text "country_of_origin",     default: "xxx",         null: false
     t.text "country_registered",    default: "xxx",         null: false
@@ -698,7 +712,8 @@ ActiveRecord::Schema.define(version: 20150225145528) do
   add_index "plant_variety_detail", ["data_attribution"], name: "idx_143926_data_provenance", using: :btree
   add_index "plant_variety_detail", ["plant_variety_name"], name: "idx_143926_plant_variety_name", using: :btree
 
-  create_table "pop_locus_genotype_alleles", primary_key: "allele_number", force: :cascade do |t|
+  create_table "pop_locus_genotype_alleles", id: false, force: :cascade do |t|
+    t.text "allele_number"
     t.text "plant_population",     default: "unspecified", null: false
     t.text "mapping_locus",        default: "unspecified", null: false
     t.text "locus_genotype",       default: "unspecified", null: false
@@ -723,12 +738,14 @@ ActiveRecord::Schema.define(version: 20150225145528) do
   add_index "pop_locus_genotype_alleles", ["plant_population", "mapping_locus", "locus_genotype", "allele_number"], name: "idx_143991_fk_population_locus_genotype_alleles_2", using: :btree
   add_index "pop_locus_genotype_alleles", ["plant_population"], name: "idx_143991_plant_population", using: :btree
 
-  create_table "pop_type_lookup", primary_key: "population_type", force: :cascade do |t|
+  create_table "pop_type_lookup", id: false, force: :cascade do |t|
+    t.text "population_type"
     t.text "population_class", default: "unspecified", null: false
     t.text "assigned_by_whom", default: "unspecified", null: false
   end
 
-  create_table "population_genotypes", primary_key: "plant_population", force: :cascade do |t|
+  create_table "population_genotypes", id: false, force: :cascade do |t|
+    t.text "plant_population"
     t.text "mapping_locus",         default: "unspecified", null: false
     t.text "zygote_locus_genotype", default: "unspecified", null: false
     t.text "locus_code_system",     default: "unspecified", null: false
@@ -745,7 +762,8 @@ ActiveRecord::Schema.define(version: 20150225145528) do
   add_index "population_genotypes", ["plant_population"], name: "idx_143947_plant_population", using: :btree
   add_index "population_genotypes", ["zygote_locus_genotype"], name: "idx_143947_genotype", using: :btree
 
-  create_table "population_loci", primary_key: "mapping_locus", force: :cascade do |t|
+  create_table "population_loci", id: false, force: :cascade do |t|
+    t.text "mapping_locus"
     t.text "plant_population",  default: "unspecified", null: false
     t.text "marker_assay_name", default: "unspecified", null: false
     t.text "defined_by_whom",   default: "unspecified", null: false
@@ -762,7 +780,8 @@ ActiveRecord::Schema.define(version: 20150225145528) do
   add_index "population_loci", ["marker_assay_name"], name: "idx_143961_marker_assay", using: :btree
   add_index "population_loci", ["plant_population"], name: "idx_143961_plant_population", using: :btree
 
-  create_table "population_locus_alleles", primary_key: "plant_population", force: :cascade do |t|
+  create_table "population_locus_alleles", id: false, force: :cascade do |t|
+    t.text "plant_population"
     t.text "mapping_locus",        default: "unspecified", null: false
     t.text "gametic_locus_allele", default: "unspecified", null: false
     t.text "marker_variation",     default: "unspecified", null: false
@@ -783,7 +802,8 @@ ActiveRecord::Schema.define(version: 20150225145528) do
   add_index "population_locus_alleles", ["marker_variation"], name: "idx_143975_marker_variation", using: :btree
   add_index "population_locus_alleles", ["plant_population"], name: "idx_143975_plant_population", using: :btree
 
-  create_table "primers", primary_key: "primer", force: :cascade do |t|
+  create_table "primers", id: false, force: :cascade do |t|
+    t.text "primer"
     t.text "sequence",                  default: "unspecified", null: false
     t.text "sequence_id",               default: "unspecified", null: false
     t.text "sequence_source_acronym",   default: "unspecified", null: false
@@ -800,9 +820,6 @@ ActiveRecord::Schema.define(version: 20150225145528) do
     t.text "data_status",               default: "unspecified", null: false
     t.text "confirmed_by_whom",         default: "unspecified", null: false
   end
-
-# Could not dump table "probes" because of following StandardError
-#   Unknown type 'probes_pcr_yes_or_no' for column 'pcr_yes_or_no'
 
   create_table "proccessed_trait_datasets", primary_key: "proccessed_trait_dataset_id", force: :cascade do |t|
     t.text "trial_id",                         default: "unspecified", null: false
@@ -910,9 +927,10 @@ ActiveRecord::Schema.define(version: 20150225145528) do
   add_index "qtl_jobs", ["linkage_map_id"], name: "idx_144140_linkage_map_id", using: :btree
   add_index "qtl_jobs", ["qtl_software", "qtl_method"], name: "idx_144140_qtl_software", using: :btree
 
-  create_table "restriction_enzymes", primary_key: "restriction_enzyme", force: :cascade do |t|
-    t.text "recognition_site", default: "unspecified", null: false
-    t.text "data_provenance",                          null: false
+  create_table "restriction_enzymes", id: false, force: :cascade do |t|
+    t.text "restriction_enzyme"
+    t.text "recognition_site",   default: "unspecified", null: false
+    t.text "data_provenance",                            null: false
   end
 
   create_table "row_plot_positions", primary_key: "row_plot_position_id", force: :cascade do |t|
@@ -1051,7 +1069,8 @@ ActiveRecord::Schema.define(version: 20150225145528) do
 
   add_index "users", ["login"], name: "index_users_on_login", unique: true, using: :btree
 
-  create_table "version", primary_key: "version", force: :cascade do |t|
+  create_table "version", id: false, force: :cascade do |t|
+    t.text "version"
     t.date "date"
     t.text "updated_by_whom", default: "unspecified", null: false
     t.text "comments",                                null: false


### PR DESCRIPTION
The autogenerated CropStore schema migration had several problems which prevented certain ActiveRecord joins from functioning correctly. The issue is associated with treatment of primary keys in RoR migrations (by default RoR assumes - incorrectly in our case - that the primary key of a table is of type INT; for all tables without an explicitly defined primary key an `id` column is automatically generated).