### PR TITLE
Do not make references to grid data in model layer

### DIFF
--- a/app/controllers/plant_lines_controller.rb
+++ b/app/controllers/plant_lines_controller.rb
@@ -4,20 +4,10 @@ class PlantLinesController < ApplicationController
     respond_to do |format|
       format.html
       format.json do
-        plant_lines = PlantLine.grid_data(grid_data_params)
+        plant_lines = PlantLine.filter(params)
         grid_data = ApplicationDecorator.decorate(plant_lines)
         render json: grid_data.as_grid_data
       end
     end
-  end
-
-  private
-
-  def grid_data_params
-    params.permit(:search,
-                  query: [
-                    'plant_populations.plant_population_id',
-                    plant_line_name: []
-                  ])
   end
 end

--- a/app/controllers/plant_populations_controller.rb
+++ b/app/controllers/plant_populations_controller.rb
@@ -3,7 +3,7 @@ class PlantPopulationsController < ApplicationController
     respond_to do |format|
       format.html
       format.json do
-        plant_populations = PlantPopulation.grid_data
+        plant_populations = PlantPopulation.grouped
         grid_data = ApplicationDecorator.decorate(plant_populations)
         render json: grid_data.as_grid_data
       end

--- a/app/models/plant_population.rb
+++ b/app/models/plant_population.rb
@@ -26,8 +26,8 @@ class PlantPopulation < ActiveRecord::Base
     where.not(canonical_population_name: '')
   end
 
-  def self.grid_data
-    columns = [
+  def self.grouped(columns: nil, count: nil)
+    columns ||= [
       'plant_populations.plant_population_id',
       'plant_populations.species',
       :canonical_population_name,
@@ -36,11 +36,13 @@ class PlantPopulation < ActiveRecord::Base
       :population_type
     ]
 
-    select(columns + ['count(plant_lines.plant_line_name)']).
+    count = 'count(plant_lines.plant_line_name)'
+
+    select(columns + [count]).
       includes(:plant_lines).
       group(columns).
       drop_dummies.
       order(:plant_population_id).
-      pluck(*(columns + ['count(plant_lines.plant_line_name)']))
+      pluck(*(columns + [count]))
   end
 end

--- a/spec/decorators/application_decorator_spec.rb
+++ b/spec/decorators/application_decorator_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe ApplicationDecorator do
   describe '#as_grid_data' do
     it 'returns proper datatables hash' do
       pps = create_list(:plant_population, 4)
-      gd = ApplicationDecorator.decorate(PlantPopulation.grid_data)
+      gd = ApplicationDecorator.decorate(PlantPopulation.grouped)
       expect(gd.as_grid_data[:recordsTotal]).to eq 4
       expect(gd.as_grid_data[:data].size).to eq 4
       expect(gd.as_grid_data[:data].map(&:first)).to match_array pps.map(&:id)

--- a/spec/models/plant_line_spec.rb
+++ b/spec/models/plant_line_spec.rb
@@ -8,14 +8,14 @@ RSpec.describe PlantLine do
     expect{ pl.subtaxa }.to raise_error NoMethodError
   end
 
-  describe '#grid_data' do
+  describe '#filter' do
     it 'returns empty result when no plant lines found' do
-      expect(PlantLine.grid_data(plant_line_names: [1])).to be_empty
+      expect(PlantLine.filter(plant_line_names: [1])).to be_empty
     end
 
     it 'orders populations by common name' do
       plids = create_list(:plant_line, 3).map(&:plant_line_name)
-      gd = PlantLine.grid_data(query: { plant_line_name: plids })
+      gd = PlantLine.filter(query: { plant_line_name: plids })
       expect(gd.map(&:first)).to eq plids.sort
     end
 
@@ -30,7 +30,7 @@ RSpec.describe PlantLine do
                    data_owned_by: 'dob',
                    organisation: 'o')
 
-      gd = PlantLine.grid_data(
+      gd = PlantLine.filter(
         query: { plant_line_name: [pl.plant_line_name] }
       )
       expect(gd.count).to eq 1
@@ -40,15 +40,15 @@ RSpec.describe PlantLine do
     it 'will not get all when no param permitted' do
       # NOTE: means - strong params should prevent passing {} to where
       create(:plant_line)
-      expect(PlantLine.grid_data(query: { common_name: 'cn' })).to be_empty
-      expect(PlantLine.grid_data(query: {})).to be_empty
+      expect(PlantLine.filter(query: { common_name: 'cn' })).to be_empty
+      expect(PlantLine.filter(query: {})).to be_empty
     end
 
     it 'will only query by permitted params' do
       create(:plant_line, common_name: 'cn', plant_line_name: 'pln')
       create(:plant_line, common_name: 'cn', plant_line_name: 'nlp')
       create(:plant_line, common_name: 'nc', plant_line_name: 'pln')
-      gd = PlantLine.grid_data(
+      gd = PlantLine.filter(
         query: { common_name: 'cn', plant_line_name: ['pln'] }
       )
       expect(gd.count).to eq 2
@@ -64,7 +64,7 @@ RSpec.describe PlantLine do
       end
 
       it 'supports querying by associated objects' do
-        gd = PlantLine.grid_data(
+        gd = PlantLine.filter(
           query: {
             'plant_populations.plant_population_id' => @pp.plant_population_id
           }
@@ -75,7 +75,7 @@ RSpec.describe PlantLine do
       end
 
       it 'supports multi-criteria queries' do
-        gd = PlantLine.grid_data(
+        gd = PlantLine.filter(
           query: {
             'plant_populations.plant_population_id' => @pp.plant_population_id,
             plant_line_name: [@pls[1].plant_line_name]

--- a/spec/models/plant_population_spec.rb
+++ b/spec/models/plant_population_spec.rb
@@ -15,9 +15,9 @@ RSpec.describe PlantPopulation do
     end
   end
 
-  describe '#grid_data' do
+  describe '#grouped' do
     it 'returns empty result when no plant population is present' do
-      expect(PlantPopulation.grid_data).to be_empty
+      expect(PlantPopulation.grouped).to be_empty
     end
 
     it 'properly calculates associated plant lines number' do
@@ -27,7 +27,7 @@ RSpec.describe PlantPopulation do
       create(:plant_population_list, plant_population: pps[0], plant_line: pls[1])
       create(:plant_population_list, plant_population: pps[1], plant_line: pls[2])
       create(:plant_population_list, plant_population: pps[1], plant_line: pls[1])
-      gd = PlantPopulation.grid_data
+      gd = PlantPopulation.grouped
       expect(gd).not_to be_empty
       expect(gd.size).to eq 3
       expect(gd.map(&:last)).to contain_exactly 2, 2, 0
@@ -36,12 +36,12 @@ RSpec.describe PlantPopulation do
     it 'filters out dummy populations' do
       create(:plant_population)
       create(:plant_population, canonical_population_name: '')
-      expect(PlantPopulation.grid_data.size).to eq 1
+      expect(PlantPopulation.grouped.size).to eq 1
     end
 
     it 'orders populations by population name' do
       ppids = create_list(:plant_population, 3).map(&:plant_population_id)
-      expect(PlantPopulation.grid_data.map(&:first)).to eq ppids.sort
+      expect(PlantPopulation.grouped.map(&:first)).to eq ppids.sort
     end
 
     it 'gets proper columns' do
@@ -54,7 +54,7 @@ RSpec.describe PlantPopulation do
              male_parent_line: mpl,
              population_type: 'pp_type')
 
-      gd = PlantPopulation.grid_data
+      gd = PlantPopulation.grouped
       expect(gd.count).to eq 1
       data = ['ssp', 'cpn', fpl.plant_line_name, mpl.plant_line_name, 'pp_type', 0]
       expect(gd[0][1..-1]).to eq data


### PR DESCRIPTION
Regarding #59 - I am OK with handling both `:query` and `:search` by the same method (at least at this point). However I am not entirely happy with the name `.grid_data`. In this PR I suggest one possible way to rename and somewhat generalize these methods (not included in the PR is actual usage but now they allow to fetch less data for autocomplete fields).

What do you think?