### PR TITLE
Genetic status input / select alternative

### DIFF
--- a/app/assets/javascripts/errors.coffee
+++ b/app/assets/javascripts/errors.coffee
@@ -20,11 +20,11 @@ window.Errors =
     data = {}
     errors = []
 
-    attrs = $(form).find('[name]').not('[type=hidden]').map(-> this.name)
+    attrs = $(form).find('[name]:enabled').not('[type=hidden]').map(-> this.name)
     required = $(form).find('.required, [required]').map(-> this.name)
 
     $.each(attrs, (idx, attr) ->
-      val = $(form).find('#' + attr).val()
+      val = $(form).find("[name=#{attr}]:enabled").val()
       data[attr] = val
       if $.inArray(attr, required) != -1 && $.trim(val) == ''
         errors.push('#' + attr)

--- a/app/assets/javascripts/input_or_select.coffee
+++ b/app/assets/javascripts/input_or_select.coffee
@@ -1,0 +1,36 @@
+class InputOrSelect
+  constructor: (el) ->
+    @$el = $(el)
+    @basename = @$el.find('[name]').attr('name')
+
+  $: (args) =>
+    @$el.find(args)
+
+  bind: =>
+    $select = @$("select[name=#{@basename}]")
+    $input = @$("input[name=#{@basename}]")
+    $clear_input = @$("a.clear-input")
+
+    $select.on 'select2:select', => $input.prop(disabled: true)
+    $select.on 'select2:unselect', => $input.prop(disabled: false)
+
+    $input.on 'keyup', =>
+      val = $.trim($input.val())
+
+      if val.length > 0
+        $select.prop(disabled: true)
+        $clear_input.removeClass('hidden')
+      else
+        $select.prop(disabled: false)
+        $clear_inputaddClass('hidden')
+
+    $clear_input.on 'click', (event) =>
+      event.preventDefault()
+
+      $input.val('')
+      $select.prop(disabled: false)
+      $clear_input.addClass('hidden')
+
+$.fn.inputOrSelect = ->
+  new InputOrSelect(this).bind()
+

--- a/app/assets/javascripts/submissions.coffee
+++ b/app/assets/javascripts/submissions.coffee
@@ -66,8 +66,10 @@ $ ->
 
     $('.edit_submission .previous-line-name').select2(plantLineSelectOptions())
     $('.edit_submission .genetic-status').select2(plantLineGeneticStatusSelectOptions())
-
     $('.edit_submission .genetic-status-wrapper').inputOrSelect()
+    $('.edit_submission .new-plant-line-for-list input[type=text]').on 'keydown', (event) ->
+      if event.keyCode == 13 # Enter key
+        event.preventDefault() # Prevent form submission
 
   $('.add-new-plant-line-for-list').on 'click', (event) ->
     $form = $('.new-plant-line-for-list')

--- a/app/assets/javascripts/submissions.coffee
+++ b/app/assets/javascripts/submissions.coffee
@@ -20,9 +20,7 @@ plantLineListSelectOptions = ->
   $.extend({}, plantLineSelectOptions(), multiple: true)
 
 plantLineGeneticStatusSelectOptions = ->
-  multiple: true
-  tags: true
-  maximumSelectionLength: 1
+  allowClear: true
 
 defaultSelectOptions = ->
   allowClear: true
@@ -68,6 +66,8 @@ $ ->
 
     $('.edit_submission .previous-line-name').select2(plantLineSelectOptions())
     $('.edit_submission .genetic-status').select2(plantLineGeneticStatusSelectOptions())
+
+    $('.edit_submission .genetic-status-wrapper').inputOrSelect()
 
   $('.add-new-plant-line-for-list').on 'click', (event) ->
     $form = $('.new-plant-line-for-list')

--- a/app/assets/stylesheets/submissions.sass
+++ b/app/assets/stylesheets/submissions.sass
@@ -46,3 +46,23 @@
 
     button.cancel-new-plant-line-for-list
       @extend .btn, .btn-default
+
+  .genetic-status-alternative
+
+  .genetic-status-input
+    position: relative
+
+    .clear-input
+      position: absolute
+      top: 0
+      right: 0
+      display: inline-block
+      width: 1.25em
+      height: 2.5em
+      padding: 0.5em 1.5em 0.5em 1em
+      cursor: pointer
+      color: $gray-base
+
+      &:hover
+        text-decoration: none !important
+

--- a/app/views/submissions/steps/_step03.html.haml
+++ b/app/views/submissions/steps/_step03.html.haml
@@ -58,9 +58,16 @@
         = text_area_tag :comments, nil, class: 'form-control'
         %p.help-block Optional
 
-      .form-group
-        = label_tag :genetic_status, 'Genetic status'
-        = select_tag :genetic_status, options_for_select(PlantLine.genetic_statuses), class: 'genetic-status form-control', data: { placeholder: "Search and select existing or enter new status" }
+      .form-group.genetic-status-wrapper
+        .genetic-status-select
+          = label_tag :genetic_status, 'Genetic status'
+          = select_tag :genetic_status, options_for_select(PlantLine.genetic_statuses), prompt: '', class: 'genetic-status form-control', data: { placeholder: "Select existing status" }
+
+        .genetic-status-alternative or
+        .genetic-status-input
+          = text_field_tag :genetic_status, nil, class: 'form-control', placeholder: "Enter new status"
+          %a.clear-input.hidden{href: '#'} ×
+
         %p.help-block Optional
 
       .action-buttons


### PR DESCRIPTION
This PR intends to fix #63 by introducing separate but mutually exclusive form elements for selecting existing value and entering new value for genetic status. Using any one disables the other.

If accepted the same solution could be used for #62.