### PR TITLE
Submission type support

### DIFF
--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -20,7 +20,7 @@ class SubmissionsController < ApplicationController
   end
 
   def create
-    submission = current_user.submissions.create!
+    submission = current_user.submissions.create!(submission_create_params)
     redirect_to edit_submission_path(submission)
   end
 
@@ -67,6 +67,11 @@ class SubmissionsController < ApplicationController
 
   def submission_params
     params.require(:submission)
+  end
+
+  # Allow setting submission_type only on create
+  def submission_create_params
+    params.require(:submission).permit(:submission_type)
   end
 
   def submission_content_params

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -2,9 +2,12 @@ class Submission < ActiveRecord::Base
 
   STEPS = %w(step01 step02 step03 step04)
 
+  enum submission_type: %i(population traits qtl linkage_map)
+
   belongs_to :user
 
   validates :user, presence: true
+  validates :submission_type, presence: true
   validates :step, inclusion: { in: STEPS }
 
   before_validation :set_defaults, on: :create

--- a/db/migrate/20150221153705_create_submissions.rb
+++ b/db/migrate/20150221153705_create_submissions.rb
@@ -1,11 +1,13 @@
 class CreateSubmissions < ActiveRecord::Migration
   def change
     create_table :submissions do |t|
-      t.timestamps null: false
       t.references :user, null: false
       t.string :step, null: false
       t.json :content, null: false, default: {}
-      t.boolean :finalized, null: false, default: false
+      t.boolean :finalized, null: false, default: false, index: true
+      t.integer :submission_type, null: false, index: true
+
+      t.timestamps null: false
     end
 
     add_index :submissions, :user_id

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -481,14 +481,17 @@ ActiveRecord::Schema.define(version: 20150225145528) do
   end
 
   create_table "submissions", force: :cascade do |t|
-    t.datetime "created_at",                 null: false
-    t.datetime "updated_at",                 null: false
-    t.integer  "user_id",                    null: false
-    t.string   "step",                       null: false
-    t.json     "content",    default: {},    null: false
-    t.boolean  "finalized",  default: false, null: false
+    t.integer  "user_id",                         null: false
+    t.string   "step",                            null: false
+    t.json     "content",         default: {},    null: false
+    t.boolean  "finalized",       default: false, null: false
+    t.integer  "submission_type",                 null: false
+    t.datetime "created_at",                      null: false
+    t.datetime "updated_at",                      null: false
   end
 
+  add_index "submissions", ["finalized"], name: "index_submissions_on_finalized", using: :btree
+  add_index "submissions", ["submission_type"], name: "index_submissions_on_submission_type", using: :btree
   add_index "submissions", ["user_id"], name: "index_submissions_on_user_id", using: :btree
 
   create_table "taxonomy_terms", force: :cascade do |t|

--- a/spec/factories/submission.rb
+++ b/spec/factories/submission.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :submission do
-    submission_type 0
+    submission_type :population
     user
   end
 end

--- a/spec/factories/submission.rb
+++ b/spec/factories/submission.rb
@@ -1,5 +1,6 @@
 FactoryGirl.define do
   factory :submission do
+    submission_type 0
     user
   end
 end

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -6,14 +6,12 @@ RSpec.describe Submission do
   it { should validate_presence_of(:submission_type) }
 
   describe '#submission_type' do
-    let(:submission) { create(:submission) }
+    let(:submission) { build(:submission) }
 
     it 'allows only certain submission type values' do
       %w(population traits qtl linkage_map).each do |t|
         submission.submission_type = t
-        expect(submission.save).to be_truthy
-        submission.reload
-        expect(submission.submission_type).to eq t
+        expect(submission.valid?).to be_truthy
         expect(submission.send(t+'?')).to be_truthy
       end
       expect { submission.submission_type = 'wrong_submission_type' }.
@@ -22,11 +20,12 @@ RSpec.describe Submission do
 
     it 'honors symbols as type values' do
       submission.submission_type = :population
-      expect(submission.save).to be_truthy
+      expect(submission.valid?).to be_truthy
     end
 
     it 'provides handy scopes to query certain types' do
-      submission.submission_type = :population
+      # submission.submission_type = :population
+      create(:submission)
       create(:submission, submission_type: :qtl)
       create(:submission, submission_type: :qtl)
       expect(Submission.qtl.count).to eq 2

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -2,6 +2,40 @@ require 'rails_helper'
 
 RSpec.describe Submission do
 
+  it { should validate_presence_of(:user) }
+  it { should validate_presence_of(:submission_type) }
+
+  describe '#submission_type' do
+    let(:submission) { create(:submission) }
+
+    it 'allows only certain submission type values' do
+      %w(population traits qtl linkage_map).each do |t|
+        submission.submission_type = t
+        expect(submission.save).to be_truthy
+        submission.reload
+        expect(submission.submission_type).to eq t
+        expect(submission.send(t+'?')).to be_truthy
+      end
+      expect { submission.submission_type = 'wrong_submission_type' }.
+        to raise_error ArgumentError
+    end
+
+    it 'honors symbols as type values' do
+      submission.submission_type = :population
+      expect(submission.save).to be_truthy
+    end
+
+    it 'provides handy scopes to query certain types' do
+      submission.submission_type = :population
+      create(:submission, submission_type: :qtl)
+      create(:submission, submission_type: :qtl)
+      expect(Submission.qtl.count).to eq 2
+      expect(Submission.population.count).to eq 1
+      expect(Submission.linkage_map.count).to eq 0
+      expect(Submission.traits.count).to eq 0
+    end
+  end
+
   describe '#content' do
     before {
       subject.content = {

--- a/spec/requests/submissions_spec.rb
+++ b/spec/requests/submissions_spec.rb
@@ -17,8 +17,8 @@ RSpec.describe "Submission management", type: :request do
     before { login_as(user) }
 
     describe "POST /submissions" do
-      it "creates default submission and redirects to edit" do
-        post "/submissions"
+      it "creates submission of given type and redirects to edit" do
+        post "/submissions", submission: { submission_type: 'qtl' }
         expect(response).to redirect_to(edit_submission_path(Submission.last))
       end
     end
@@ -39,6 +39,12 @@ RSpec.describe "Submission management", type: :request do
       it "updates submission with permitted params" do
         put "/submissions/#{submission.id}", submission: { content: { name: 'Population A' } }
         expect(submission.reload.content.step01.name).to eq('Population A')
+      end
+
+      it "ignores submission type updates" do
+        put "/submissions/#{submission.id}",
+          submission: { content: { name: 'Population A' }, submission_type: 'qtl' }
+        expect(submission.reload.population?).to be_truthy
       end
 
       it "ignores not-permitted params" do


### PR DESCRIPTION
We need it to differentiate various types of submissions (currently planning to support four).