### PR TITLE
decomposed filter into two model concerns

### DIFF
--- a/app/assets/javascripts/submissions.coffee
+++ b/app/assets/javascripts/submissions.coffee
@@ -8,10 +8,12 @@ plantLineSelectOptions = ->
     url: "/plant_lines"
     dataType: 'json'
     data: (params) ->
-      search: params.term
+      search:
+        plant_line_name: params.term
       page: params.page
     processResults: (data, page) ->
-      results: $.map(data.data, (row) -> { id: row[0], text: row[0] })
+      console.log data
+      results: $.map(data.data, (row) -> { id: row.plant_line_name, text: row.plant_line_name })
   escapeMarkup: (markup) -> markup
   templateResult: formatPlantLine
   templateSelection: formatPlantLine

--- a/app/assets/javascripts/submissions.coffee
+++ b/app/assets/javascripts/submissions.coffee
@@ -12,8 +12,7 @@ plantLineSelectOptions = ->
         plant_line_name: params.term
       page: params.page
     processResults: (data, page) ->
-      console.log data
-      results: $.map(data.data, (row) -> { id: row.plant_line_name, text: row.plant_line_name })
+      results: $.map(data.data, (row) -> { id: row[0], text: row[0] })
   escapeMarkup: (markup) -> markup
   templateResult: formatPlantLine
   templateSelection: formatPlantLine

--- a/app/controllers/plant_lines_controller.rb
+++ b/app/controllers/plant_lines_controller.rb
@@ -4,7 +4,7 @@ class PlantLinesController < ApplicationController
     respond_to do |format|
       format.html
       format.json do
-        plant_lines = PlantLine.table_data(params)
+        plant_lines = PlantLine.filtered(params)
         grid_data = ApplicationDecorator.decorate(plant_lines)
         render json: grid_data.as_grid_data
       end

--- a/app/controllers/plant_lines_controller.rb
+++ b/app/controllers/plant_lines_controller.rb
@@ -4,7 +4,7 @@ class PlantLinesController < ApplicationController
     respond_to do |format|
       format.html
       format.json do
-        plant_lines = PlantLine.filter(params)
+        plant_lines = PlantLine.table_data(params)
         grid_data = ApplicationDecorator.decorate(plant_lines)
         render json: grid_data.as_grid_data
       end

--- a/app/controllers/plant_populations_controller.rb
+++ b/app/controllers/plant_populations_controller.rb
@@ -3,7 +3,7 @@ class PlantPopulationsController < ApplicationController
     respond_to do |format|
       format.html
       format.json do
-        plant_populations = PlantPopulation.grouped
+        plant_populations = PlantPopulation.grouped(params)
         grid_data = ApplicationDecorator.decorate(plant_populations)
         render json: grid_data.as_grid_data
       end

--- a/app/decorators/application_decorator.rb
+++ b/app/decorators/application_decorator.rb
@@ -16,8 +16,4 @@ class ApplicationDecorator < Draper::Decorator
       data: data
     }
   end
-
-  def meaningless?(value)
-    ['unspecified', 'not applicable', 'none'].include? value
-  end
 end

--- a/app/decorators/plant_population_submission_decorator.rb
+++ b/app/decorators/plant_population_submission_decorator.rb
@@ -24,10 +24,9 @@ class PlantPopulationSubmissionDecorator < SubmissionDecorator
   end
 
   def details_path
-    #TODO FIXE this will not work until #83 is solved
     Rails.application.routes.url_helpers.plant_populations_path(
       query: {
-        plant_population_name: population_name
+        plant_population_id: population_name
       }
     )
   end

--- a/app/helpers/data_tables_helper.rb
+++ b/app/helpers/data_tables_helper.rb
@@ -1,0 +1,20 @@
+module DataTablesHelper
+  def datatables_source
+    url_for(controller: controller_name, action: action_name, query: params[:query])
+  end
+
+  def datatable_tag
+    content_tag(
+      :table,
+      class: 'table table-condensed data-table',
+      id: controller_name.dasherize,
+      data: { ajax: datatables_source }
+    ) do
+      content_tag(:thead) do
+        content_tag(:tr) do
+          yield
+        end
+      end
+    end
+  end
+end

--- a/app/models/concerns/filterable.rb
+++ b/app/models/concerns/filterable.rb
@@ -1,0 +1,45 @@
+# Single Concern for all searcheable/filterable models.
+# Provides the 'filter' scope, to be used like this:
+#  - params[:query] - exact filtering, also by associated model fields e.g.
+#    - query: { common_name: 'cn', plant_line_name: ['pln'] }
+#    - query: { 'plant_populations.plant_population_id' => 'pid' }
+#      - this one performs the required join
+#  - params[:search] - ILIKE filtering
+#    - search: { common_name: 'cn' }
+#  - possible multiple search, and multiple query criteria
+#  - IMPORTANT: requires declared self.permitted_params for strong
+#               parameters filtering
+#  - possible joint search and query criteria
+module Filterable extend ActiveSupport::Concern
+
+  included do
+    def self.filter(params)
+      params = filter_params(params)
+      query = if params[:query].present? || params[:search].present?
+        query = all
+        query = query.where(params[:query]) if params[:query].present?
+        params[:search].each do |k,v|
+          query = query.where("#{k} ILIKE ?", "%#{v}%")
+        end if params[:search].present?
+        query
+      else
+        none
+      end
+
+      params[:query].each do |k,_|
+        query = query.joins(k.to_s.split('.')[0].to_sym) if k.to_s.include? '.'
+      end if params[:query].present?
+      query
+    end
+
+    private
+
+    def self.filter_params(unsafe_params)
+      unsafe_params = ActionController::Parameters.new(unsafe_params)
+      unsafe_params.permit(permitted_params)
+    end
+
+    # By default, do not permit any parameter
+    def self.permitted_params; end
+  end
+end

--- a/app/models/concerns/pluckable.rb
+++ b/app/models/concerns/pluckable.rb
@@ -1,0 +1,20 @@
+# Single Concern for all models to pluck certain columns for data tables
+# Pass columns in table like that:
+# [
+#   'plant_line_name',
+#   'taxonomy_terms.name'
+# ]
+module Pluckable extend ActiveSupport::Concern
+  included do
+    def self.pluck_columns(columns)
+      query = self.all
+      columns.each do |column|
+        relation = column.to_s.split('.')[0].pluralize if column.to_s.include? '.'
+        next unless relation
+        relation = relation.singularize unless reflections.keys.include?(relation)
+        query = query.joins(relation.to_sym)
+      end
+      query.pluck(*columns)
+    end
+  end
+end

--- a/app/models/plant_line.rb
+++ b/app/models/plant_line.rb
@@ -25,7 +25,7 @@ class PlantLine < ActiveRecord::Base
 
   scope :by_name, -> { order(:plant_line_name) }
 
-  def self.table_data(params)
+  def self.filtered(params)
     query = filter(params)
     query.by_name.pluck_columns(table_columns)
   end

--- a/app/models/plant_population.rb
+++ b/app/models/plant_population.rb
@@ -29,7 +29,6 @@ class PlantPopulation < ActiveRecord::Base
     count = 'count(plant_lines.plant_line_name)'
     query = (params && params[:query].present?) ? filter(params) : all
     query.
-      select(table_columns + [count]).
       includes(:plant_lines).
       group(table_columns).
       by_name.

--- a/app/views/plant_lines/index.html.haml
+++ b/app/views/plant_lines/index.html.haml
@@ -2,14 +2,11 @@
 
 = link_to 'TEMP LINK TO Plant populations', plant_populations_path
 
-- data_src = plant_lines_path(query: params[:query])
-%table#plant-lines.table.table-condensed.data-table{ data: { ajax: data_src }}
-  %thead
-    %tr
-      %th Line name
-      %th Taxonomy
-      %th Common name
-      %th Previous line name
-      %th Entry date
-      %th Data owner
-      %th Organisation
+= datatable_tag do
+  %th Line name
+  %th Taxonomy
+  %th Common name
+  %th Previous line name
+  %th Entry date
+  %th Data owner
+  %th Organisation

--- a/app/views/plant_populations/index.html.haml
+++ b/app/views/plant_populations/index.html.haml
@@ -1,13 +1,10 @@
 .lead Plant Populations table
 
-.container
-  %table#plant-populations.table.table-condensed.data-table{ data: { ajax: plant_populations_path }}
-    %thead
-      %tr
-        %th Population Name
-        %th Species
-        %th Canonical Name
-        %th Female Parent Line
-        %th Male Parent Line
-        %th Type
-        %th Plant lines
+= datatable_tag do
+  %th Population Name
+  %th Species
+  %th Canonical Name
+  %th Female Parent Line
+  %th Male Parent Line
+  %th Type
+  %th Plant lines

--- a/spec/controllers/plant_lines_controller_spec.rb
+++ b/spec/controllers/plant_lines_controller_spec.rb
@@ -2,24 +2,24 @@ require 'rails_helper'
 
 RSpec.describe PlantLinesController do
   context '#index' do
-    it 'returns table template on html request' do
+    it 'returns table template on html format request' do
       get :index
       expect(response).to render_template('plant_lines/index')
       expect(response).to render_template('layouts/application')
     end
 
-    it 'does not raise error on wrong parameter ajax request' do
+    it 'does not raise error on wrong parameter json format request' do
       get :index, format: :json, query: { plant_line_name: 'wrong!' }
       expect(response).to have_http_status(:success)
     end
 
-    it 'does not render htmls on ajax request' do
+    it 'does not render htmls on json format request' do
       get :index, format: :json
       expect(response).not_to render_template('plant_lines/index')
       expect(response).not_to render_template('layouts/application')
     end
 
-    it 'returns datatables json on ajax request' do
+    it 'returns datatables json on json format request' do
       plns = create_list(:plant_line, 2).map(&:plant_line_name)
       get :index, format: :json, query: { plant_line_name: plns }
       expect(response.content_type).to eq 'application/json'

--- a/spec/controllers/plant_lines_controller_spec.rb
+++ b/spec/controllers/plant_lines_controller_spec.rb
@@ -43,5 +43,16 @@ RSpec.describe PlantLinesController do
       expect(json['data'].map(&:first)).to match_array ['pln','pln']
       expect(json['data'].map(&:third)).to match_array ['cn','nc']
     end
+
+    it 'returns search results and provides PL id in the first element' do
+      plns = create_list(:plant_line, 2).map(&:plant_line_name)
+      get :index, format: :json, search: { plant_line_name: plns[0][1..-2] }
+      expect(response.content_type).to eq 'application/json'
+      json = JSON.parse(response.body)
+      expect(json['recordsTotal']).to eq 1
+      expect(json['data'].size).to eq 1
+      expect(json['data'][0].size).to eq 7
+      expect(json['data'][0][0]).to eq plns[0]
+    end
   end
 end

--- a/spec/controllers/plant_populations_controller_spec.rb
+++ b/spec/controllers/plant_populations_controller_spec.rb
@@ -2,19 +2,19 @@ require 'rails_helper'
 
 RSpec.describe PlantPopulationsController do
   context '#index' do
-    it 'returns table template on html request' do
+    it 'returns table template on html format request' do
       get :index
       expect(response).to render_template('plant_populations/index')
       expect(response).to render_template('layouts/application')
     end
 
-    it 'does not render htmls on ajax request' do
+    it 'does not render htmls on json format request' do
       get :index, format: :json
       expect(response).not_to render_template('plant_populations/index')
       expect(response).not_to render_template('layouts/application')
     end
 
-    it 'returns datatables json on ajax request' do
+    it 'returns datatables json on json format request' do
       pps = create_list(:plant_population, 2)
       get :index, format: :json
       expect(response.content_type).to eq 'application/json'
@@ -24,7 +24,7 @@ RSpec.describe PlantPopulationsController do
       expect(json['data'].map(&:first)).to match_array pps.map(&:id)
     end
 
-    it 'supports query filtering on ajax request' do
+    it 'supports query filtering on json format request' do
       pps = create_list(:plant_population, 2).map(&:plant_population_id)
       get :index, format: :json, query: { plant_population_id: pps[0] }
       expect(response.content_type).to eq 'application/json'

--- a/spec/controllers/plant_populations_controller_spec.rb
+++ b/spec/controllers/plant_populations_controller_spec.rb
@@ -23,5 +23,15 @@ RSpec.describe PlantPopulationsController do
       expect(json['data'].size).to eq 2
       expect(json['data'].map(&:first)).to match_array pps.map(&:id)
     end
+
+    it 'supports query filtering on ajax request' do
+      pps = create_list(:plant_population, 2).map(&:plant_population_id)
+      get :index, format: :json, query: { plant_population_id: pps[0] }
+      expect(response.content_type).to eq 'application/json'
+      json = JSON.parse(response.body)
+      expect(json['recordsTotal']).to eq 1
+      expect(json['data'].size).to eq 1
+      expect(json['data'][0][0]).to eq pps[0]
+    end
   end
 end

--- a/spec/factories/plant_line.rb
+++ b/spec/factories/plant_line.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :plant_line do
-    sequence(:plant_line_name) {|n| "#{Faker::Lorem.word}_#{n}"}
+    sequence(:plant_line_name) {|n| "#{Faker::Lorem.characters(5)}_#{n}"}
     common_name { Faker::Lorem.word }
     previous_line_name { Faker::Lorem.word }
     date_entered { Faker::Date.backward }

--- a/spec/models/plant_line_spec.rb
+++ b/spec/models/plant_line_spec.rb
@@ -103,14 +103,14 @@ RSpec.describe PlantLine do
     end
   end
 
-  describe '#table_data' do
+  describe '#filtered' do
     it 'returns empty result when no plant lines found' do
-      expect(PlantLine.table_data(plant_line_names: [1])).to be_empty
+      expect(PlantLine.filtered(plant_line_names: [1])).to be_empty
     end
 
     it 'orders populations by plant line name' do
       plids = create_list(:plant_line, 3).map(&:plant_line_name)
-      td = PlantLine.table_data(query: { plant_line_name: plids })
+      td = PlantLine.filtered(query: { plant_line_name: plids })
       expect(td.map(&:first)).to eq plids.sort
     end
   end

--- a/spec/models/plant_line_spec.rb
+++ b/spec/models/plant_line_spec.rb
@@ -8,51 +8,38 @@ RSpec.describe PlantLine do
     expect{ pl.subtaxa }.to raise_error NoMethodError
   end
 
+
   describe '#filter' do
-    it 'returns empty result when no plant lines found' do
-      expect(PlantLine.filter(plant_line_names: [1])).to be_empty
+    before(:each) do
+      create(:plant_line, common_name: 'cn', plant_line_name: 'pln')
     end
 
-    it 'orders populations by common name' do
-      plids = create_list(:plant_line, 3).map(&:plant_line_name)
-      gd = PlantLine.filter(query: { plant_line_name: plids })
-      expect(gd.map(&:first)).to eq plids.sort
+    it 'serches plant_line_name' do
+      create(:plant_line, plant_line_name: 'pln pln')
+      search = PlantLine.filter(search: { plant_line_name: 'n pl' })
+      expect(search.count).to eq 1
+      expect(search.first.plant_line_name).to eq 'pln pln'
     end
 
-    it 'gets proper columns' do
-      tt = create(:taxonomy_term, name: 'tt')
-      de = Date.today
-      pl = create(:plant_line,
-                   taxonomy_term: tt,
-                   common_name: 'cn',
-                   previous_line_name: 'pln',
-                   date_entered: de,
-                   data_owned_by: 'dob',
-                   organisation: 'o')
-
-      gd = PlantLine.filter(
-        query: { plant_line_name: [pl.plant_line_name] }
-      )
-      expect(gd.count).to eq 1
-      expect(gd[0][1..-1]).to eq %w(tt cn pln) + [de] + %w(dob o)
+    it 'will only search by permitted params' do
+      search = PlantLine.filter(search: { common_name: 'n' })
+      expect(search.count).to eq 0
     end
 
     it 'will not get all when no param permitted' do
       # NOTE: means - strong params should prevent passing {} to where
-      create(:plant_line)
       expect(PlantLine.filter(query: { common_name: 'cn' })).to be_empty
       expect(PlantLine.filter(query: {})).to be_empty
     end
 
     it 'will only query by permitted params' do
-      create(:plant_line, common_name: 'cn', plant_line_name: 'pln')
       create(:plant_line, common_name: 'cn', plant_line_name: 'nlp')
       create(:plant_line, common_name: 'nc', plant_line_name: 'pln')
-      gd = PlantLine.filter(
+      search = PlantLine.filter(
         query: { common_name: 'cn', plant_line_name: ['pln'] }
       )
-      expect(gd.count).to eq 2
-      expect(gd.map(&:first)).to match_array ['pln', 'pln']
+      expect(search.count).to eq 2
+      expect(search.map(&:plant_line_name)).to match_array ['pln', 'pln']
     end
 
     context 'when associated with plant population' do
@@ -64,26 +51,67 @@ RSpec.describe PlantLine do
       end
 
       it 'supports querying by associated objects' do
-        gd = PlantLine.filter(
+        search = PlantLine.filter(
           query: {
             'plant_populations.plant_population_id' => @pp.plant_population_id
           }
         )
-        expect(gd.count).to eq 2
-        expect(gd.map(&:first)).
+        expect(search.count).to eq 2
+        expect(search.map(&:plant_line_name)).
           to match_array [@pls[0].plant_line_name, @pls[1].plant_line_name]
       end
 
       it 'supports multi-criteria queries' do
-        gd = PlantLine.filter(
+        search = PlantLine.filter(
           query: {
             'plant_populations.plant_population_id' => @pp.plant_population_id,
             plant_line_name: [@pls[1].plant_line_name]
           }
         )
-        expect(gd.count).to eq 1
-        expect(gd[0][0]).to eq @pls[1].plant_line_name
+        expect(search.count).to eq 1
+        expect(search[0].plant_line_name).to eq @pls[1].plant_line_name
       end
+
+      it 'supports both search and query criteria combined' do
+        search = PlantLine.filter(
+          query: {
+            'plant_populations.plant_population_id' => @pp.plant_population_id
+          },
+          search: { 'plant_lines.plant_line_name' => @pls[1].plant_line_name[1..-2] }
+        )
+        expect(search.count).to eq 1
+        expect(search[0].plant_line_name).to eq @pls[1].plant_line_name
+      end
+    end
+  end
+
+  describe '#pluckable' do
+    it 'gets proper data table columns' do
+      tt = create(:taxonomy_term, name: 'tt')
+      de = Date.today
+      pl = create(:plant_line,
+                  taxonomy_term: tt,
+                  common_name: 'cn',
+                  previous_line_name: 'pln',
+                  date_entered: de,
+                  data_owned_by: 'dob',
+                  organisation: 'o')
+
+      plucked = PlantLine.pluck_columns(PlantLine.table_columns)
+      expect(plucked.count).to eq 1
+      expect(plucked[0][1..-1]).to eq %w(tt cn pln) + [de] + %w(dob o)
+    end
+  end
+
+  describe '#table_data' do
+    it 'returns empty result when no plant lines found' do
+      expect(PlantLine.table_data(plant_line_names: [1])).to be_empty
+    end
+
+    it 'orders populations by plant line name' do
+      plids = create_list(:plant_line, 3).map(&:plant_line_name)
+      td = PlantLine.table_data(query: { plant_line_name: plids })
+      expect(td.map(&:first)).to eq plids.sort
     end
   end
 end


### PR DESCRIPTION
@kammerer Tomek, this is more or less what I was talking about. In principle:
 - Filterable to cover the filtering, both for :query and :search constraints, also takes care for strong_params, which are to be defined per-model
 - Pluckable (I know, a terrible name :)), that takes care for proper joins in multi-column pluck data retrieval.

So, your :search case needs only PlantLine.filter now, and I adjusted submissions.coffee to make proper query and parse the new result accordingly. NOTE - I'm not really sure where else I should change the :search query.

Anyway - including Filterable and Pluckable in subsequent models should make it much better to support further submissions and data tables, respectively.

Of course we still have "ugly" names, like table_columns or table_data - but I rather need that kind of specialized calls for smoother datatables coding.

I'm not merging it right now, tell me what you think first.