### PR TITLE
Annotations concern

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,4 +52,5 @@ group :test do
   gem 'factory_girl_rails'
   gem 'faker'
   gem 'shoulda-matchers'
+  gem 'rspec-html-matchers'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -216,11 +216,18 @@ GEM
     request_store (1.1.0)
     responders (2.0.2)
       railties (>= 4.2.0.alpha, < 5)
+    rspec (3.1.0)
+      rspec-core (~> 3.1.0)
+      rspec-expectations (~> 3.1.0)
+      rspec-mocks (~> 3.1.0)
     rspec-core (3.1.7)
       rspec-support (~> 3.1.0)
     rspec-expectations (3.1.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.1.0)
+    rspec-html-matchers (0.7.0)
+      nokogiri (~> 1)
+      rspec (~> 3)
     rspec-mocks (3.1.3)
       rspec-support (~> 3.1.0)
     rspec-rails (3.1.0)
@@ -299,6 +306,7 @@ DEPENDENCIES
   puma
   rails (= 4.2.0)
   reform (~> 1.2.6)
+  rspec-html-matchers
   rspec-rails
   sass-rails (~> 4.0.3)
   shoulda-matchers

--- a/app/assets/javascripts/data_grid.js.coffee
+++ b/app/assets/javascripts/data_grid.js.coffee
@@ -37,7 +37,41 @@ $ ->
 
 
   $('.data-table').each (i)->
-    $(this).DataTable window.configs[this.id]
+    specificConfig = window.configs[this.id]
+    if specificConfig
+      specificConfig['columnDefs'] =
+        $.merge(specificConfig['columnDefs'], window.baseColumnDefs(this.id))
+    else
+      specificConfig =
+        columnDefs: window.baseColumnDefs(this.id)
+    $(this).DataTable specificConfig
+
+
+  $('body').popover
+    selector: '[data-popover-source]'
+    placement: 'left'
+    title: 'Record metadata'
+    trigger: 'focus'
+    html: 'true'
+    content: ->
+      divId = "tmp-id-" + $.now()
+      $.ajax
+        url: $(this).data('popover-source')
+        success: (response) ->
+          $('#'+divId).html(JSON.stringify(response))
+      "<div id='#{divId}'>Loading...</div>"
+
+
+window.baseColumnDefs = (model) ->
+  [
+    targets: 'annotations'
+    render: (data, type, full, meta) ->
+      objectId = full[full.length - 1]
+      if objectId
+        '<button data-popover-source="data_tables/' + objectId + '?model=' + model + '">Metadata</button>'
+      else
+        ''
+  ]
 
 
 # Specific configurations for particular DataTables, including callbacks
@@ -73,22 +107,22 @@ window.configs =
       [
         targets: [3]
         render: (data, type, full, meta) ->
-          if data && full[8]
-            '<a href="data_tables?model=plant_lines&query[id]=' + full[8] + '">' + data + '</a>'
+          if data && full[7]
+            '<a href="data_tables?model=plant_lines&query[id]=' + full[7] + '">' + data + '</a>'
           else
             ''
       ,
         targets: [4]
         render: (data, type, full, meta) ->
-          if data && full[9]
-            '<a href="data_tables?model=plant_lines&query[id]=' + full[9] + '">' + data + '</a>'
+          if data && full[8]
+            '<a href="data_tables?model=plant_lines&query[id]=' + full[8] + '">' + data + '</a>'
           else
             ''
       ,
         targets: [6]
         render: (data, type, full, meta) ->
-          if data && data != '0' && full[7]
-            '<a href="data_tables?model=plant_lines&query[plant_populations.id]=' + full[7] + '">' + data + '</a>'
+          if data && data != '0' && full[9]
+            '<a href="data_tables?model=plant_lines&query[plant_populations.id]=' + full[9] + '">' + data + '</a>'
           else
             ''
       ]

--- a/app/controllers/data_tables_controller.rb
+++ b/app/controllers/data_tables_controller.rb
@@ -12,6 +12,12 @@ class DataTablesController < ApplicationController
     end
   end
 
+  def show
+    params[:model] = params[:model].underscore
+    object = model_param.singularize.camelize.constantize.find(params[:id])
+    render json: object.annotations_as_json
+  end
+
   private
 
   def model_param

--- a/app/models/concerns/annotable.rb
+++ b/app/models/concerns/annotable.rb
@@ -1,0 +1,29 @@
+# Single Concern for all models that have at least that set of fields:
+# t.text "comments"
+# t.text "entered_by_whom"
+# t.date "date_entered"
+# t.text "data_provenance"
+#
+# and could have one more optional field
+# t.text "data_owned_by"
+#
+# Provides common methods for dealing with these fields.
+# Should be included LAST since it redefines ref_columns field,
+# that is also important for e.g. Pluckable
+module Annotable extend ActiveSupport::Concern
+  included do
+    def annotations_as_json
+      as_json(
+        only: [
+          :comments, :entered_by_whom, :date_entered, :data_provenance
+        ] + (has_attribute?(:data_owned_by) ? [:data_owned_by] : [])
+      )
+    end
+
+    @old_ref_columns = (self.respond_to?(:ref_columns) ? ref_columns : [])
+
+    def self.ref_columns
+      @old_ref_columns + ["#{table_name}.id"]
+    end
+  end
+end

--- a/app/models/concerns/pluckable.rb
+++ b/app/models/concerns/pluckable.rb
@@ -1,20 +1,29 @@
-# Single Concern for all models to pluck certain columns for data tables
-# Pass columns in table like that:
+# Single Concern for all models to pluck columns for data tables
+# Define columns to be plucked by reloading:
+#
+#  - self.table_columns: columns visible to the end user
+#  - self.ref_columns: columns not visible to the end user, esp. references
+#
+# Columns should be defined in an array like that:
 # [
 #   'plant_line_name',
 #   'taxonomy_terms.name'
 # ]
 module Pluckable extend ActiveSupport::Concern
   included do
-    def self.pluck_columns(columns)
+    def self.pluck_columns
       query = self.all
+      columns = table_columns + ref_columns
       columns.each do |column|
         relation = column.to_s.split('.')[0].pluralize if column.to_s.include? '.'
-        next unless relation
+        next unless relation and relation != self.table_name
         relation = relation.singularize unless reflections.keys.include?(relation)
         query = query.includes(relation.to_sym)
       end
       query.pluck(*columns)
     end
+
+    def self.table_columns; [] end
+    def self.ref_columns; [] end
   end
 end

--- a/app/models/design_factor.rb
+++ b/app/models/design_factor.rb
@@ -2,4 +2,5 @@ class DesignFactor < ActiveRecord::Base
 
   has_many :plant_scoring_units
 
+  include Annotable
 end

--- a/app/models/genotype_matrix.rb
+++ b/app/models/genotype_matrix.rb
@@ -2,4 +2,5 @@ class GenotypeMatrix < ActiveRecord::Base
 
   belongs_to :linkage_map
 
+  include Annotable
 end

--- a/app/models/linkage_group.rb
+++ b/app/models/linkage_group.rb
@@ -11,4 +11,5 @@ class LinkageGroup < ActiveRecord::Base
 
   has_many :qtls
 
+  include Annotable
 end

--- a/app/models/linkage_map.rb
+++ b/app/models/linkage_map.rb
@@ -11,4 +11,5 @@ class LinkageMap < ActiveRecord::Base
 
   has_many :map_locus_hits, foreign_key: 'linkage_map_id'
 
+  include Annotable
 end

--- a/app/models/map_position.rb
+++ b/app/models/map_position.rb
@@ -6,4 +6,5 @@ class MapPosition < ActiveRecord::Base
 
   has_many :map_locus_hits, foreign_key: 'map_position'
 
+  include Annotable
 end

--- a/app/models/marker_assay.rb
+++ b/app/models/marker_assay.rb
@@ -17,4 +17,5 @@ class MarkerAssay < ActiveRecord::Base
   has_many :population_loci, class_name: 'PopulationLocus',
            foreign_key: 'marker_assay_name'
 
+  include Annotable
 end

--- a/app/models/marker_sequence_assignment.rb
+++ b/app/models/marker_sequence_assignment.rb
@@ -2,4 +2,5 @@ class MarkerSequenceAssignment < ActiveRecord::Base
 
   has_many :marker_assays, foreign_key: 'canonical_marker_name'
 
+  include Annotable
 end

--- a/app/models/plant_accession.rb
+++ b/app/models/plant_accession.rb
@@ -4,4 +4,5 @@ class PlantAccession < ActiveRecord::Base
 
   has_many :plant_scoring_units
 
+  include Annotable
 end

--- a/app/models/plant_line.rb
+++ b/app/models/plant_line.rb
@@ -31,7 +31,7 @@ class PlantLine < ActiveRecord::Base
 
   def self.table_data(params = nil)
     query = (params && params[:query].present?) ? filter(params) : all
-    query.by_name.pluck_columns(table_columns + ref_columns)
+    query.by_name.pluck_columns
   end
 
   def self.genetic_statuses
@@ -83,4 +83,6 @@ class PlantLine < ActiveRecord::Base
       'plant_variety_id'
     ]
   end
+
+  include Annotable
 end

--- a/app/models/plant_part.rb
+++ b/app/models/plant_part.rb
@@ -2,4 +2,5 @@ class PlantPart < ActiveRecord::Base
 
   has_many :plant_scoring_units
 
+  include Annotable
 end

--- a/app/models/plant_population.rb
+++ b/app/models/plant_population.rb
@@ -63,7 +63,6 @@ class PlantPopulation < ActiveRecord::Base
 
   def self.ref_columns
     [
-      'plant_populations.id',
       'female_parent_line_id',
       'male_parent_line_id'
     ]
@@ -87,4 +86,5 @@ class PlantPopulation < ActiveRecord::Base
     )
   end
 
+  include Annotable
 end

--- a/app/models/plant_population_list.rb
+++ b/app/models/plant_population_list.rb
@@ -3,4 +3,5 @@ class PlantPopulationList < ActiveRecord::Base
   belongs_to :plant_line
   belongs_to :plant_population, counter_cache: true
 
+  include Annotable
 end

--- a/app/models/plant_scoring_unit.rb
+++ b/app/models/plant_scoring_unit.rb
@@ -7,4 +7,5 @@ class PlantScoringUnit < ActiveRecord::Base
 
   has_many :trait_scores
 
+  include Annotable
 end

--- a/app/models/plant_trial.rb
+++ b/app/models/plant_trial.rb
@@ -10,7 +10,7 @@ class PlantTrial < ActiveRecord::Base
 
   def self.table_data(params = nil)
     query = (params && params[:query].present?) ? filter(params) : all
-    query.order(:trial_year).pluck_columns(table_columns)
+    query.order(:trial_year).pluck_columns
   end
 
   def self.table_columns
@@ -34,4 +34,6 @@ class PlantTrial < ActiveRecord::Base
       ]
     ]
   end
+
+  include Annotable
 end

--- a/app/models/plant_variety.rb
+++ b/app/models/plant_variety.rb
@@ -17,7 +17,7 @@ class PlantVariety < ActiveRecord::Base
 
   def self.table_data(params = nil)
     query = (params && params[:query].present?) ? filter(params) : all
-    query.by_name.pluck_columns(table_columns)
+    query.by_name.pluck_columns
   end
 
   def self.table_columns
@@ -43,4 +43,6 @@ class PlantVariety < ActiveRecord::Base
       ]
     ]
   end
+
+  include Annotable
 end

--- a/app/models/population_locus.rb
+++ b/app/models/population_locus.rb
@@ -7,4 +7,5 @@ class PopulationLocus < ActiveRecord::Base
   has_many :map_positions
   has_many :map_locus_hits
 
+  include Annotable
 end

--- a/app/models/primer.rb
+++ b/app/models/primer.rb
@@ -5,4 +5,5 @@ class Primer < ActiveRecord::Base
   has_many :marker_assays_B, class_name: 'MarkerAssay',
            foreign_key: 'primer_b'
 
+  include Annotable
 end

--- a/app/models/probe.rb
+++ b/app/models/probe.rb
@@ -2,4 +2,5 @@ class Probe < ActiveRecord::Base
 
   has_many :marker_assays, foreign_key: 'probe_name'
 
+  include Annotable
 end

--- a/app/models/processed_trait_dataset.rb
+++ b/app/models/processed_trait_dataset.rb
@@ -6,4 +6,5 @@ class ProcessedTraitDataset < ActiveRecord::Base
 
   has_many :qtls
 
+  include Annotable
 end

--- a/app/models/qtl.rb
+++ b/app/models/qtl.rb
@@ -5,4 +5,5 @@ class Qtl < ActiveRecord::Base
   belongs_to :linkage_group
   belongs_to :qtl_job
 
+  include Annotable
 end

--- a/app/models/qtl_job.rb
+++ b/app/models/qtl_job.rb
@@ -1,5 +1,6 @@
 class QtlJob < ActiveRecord::Base
 
   has_many :qtls
-  
+
+  include Annotable
 end

--- a/app/models/scoring_occasion.rb
+++ b/app/models/scoring_occasion.rb
@@ -2,4 +2,5 @@ class ScoringOccasion < ActiveRecord::Base
 
   has_many :trait_scores
 
+  include Annotable
 end

--- a/app/models/trait_descriptor.rb
+++ b/app/models/trait_descriptor.rb
@@ -6,9 +6,9 @@ class TraitDescriptor < ActiveRecord::Base
 
   def self.table_data(params = nil)
     includes(trait_scores: { plant_scoring_unit: { plant_trial: [:country, { plant_population: :taxonomy_term }]}}).
-      group(table_columns).
+      group(table_columns + ref_columns).
       order('taxonomy_terms.name, plant_trials.project_descriptor').
-      pluck(*table_columns)
+      pluck(*(table_columns + ref_columns))
   end
 
   def self.table_columns
@@ -21,4 +21,6 @@ class TraitDescriptor < ActiveRecord::Base
       'trait_scores_count'
     ]
   end
+
+  include Annotable
 end

--- a/app/models/trait_grade.rb
+++ b/app/models/trait_grade.rb
@@ -2,4 +2,5 @@ class TraitGrade < ActiveRecord::Base
 
   belongs_to :trait_descriptor
 
+  include Annotable
 end

--- a/app/models/trait_score.rb
+++ b/app/models/trait_score.rb
@@ -4,4 +4,5 @@ class TraitScore < ActiveRecord::Base
   belongs_to :scoring_occasion
   belongs_to :trait_descriptor, counter_cache: true
 
+  include Annotable
 end

--- a/app/views/data_tables/index.html.haml
+++ b/app/views/data_tables/index.html.haml
@@ -5,6 +5,11 @@
 = back_button
 
 = datatable_tag do
-  - model_param.singularize.camelize.constantize.table_columns.each do |table_column|
-    - table_column = model_param + '.' + table_column unless table_column.include? '.'
-    %th= t("tables.#{table_column}")
+  - model_class = model_param.singularize.camelize.constantize
+  - if model_class.respond_to? :table_columns
+    - model_class.table_columns.each do |table_column|
+      - table_column = model_param + '.' + table_column unless table_column.include? '.'
+      %th= t("tables.#{table_column}")
+
+  - if model_class.ancestors.include? Annotable
+    %th.annotations

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -14,3 +14,6 @@
 # ActiveSupport::Inflector.inflections(:en) do |inflect|
 #   inflect.acronym 'RESTful'
 # end
+ActiveSupport::Inflector.inflections(:en) do |inflect|
+  inflect.irregular 'locus', 'loci'
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,7 @@ Rails.application.routes.draw do
 
   resources :submissions
   resources :plant_lines, only: [:index]
-  resources :data_tables, only: [:index]
+  resources :data_tables, only: [:index, :show]
 
   get 'browse_data', to: 'data_tables#index', defaults: { model: 'plant_populations' }
 end

--- a/spec/common_helpers.rb
+++ b/spec/common_helpers.rb
@@ -1,0 +1,32 @@
+module CommonHelpers
+  def annotable_tables
+    %w(
+      design_factors
+      genotype_matrices
+      linkage_groups
+      linkage_maps
+      map_positions
+      marker_assays
+      marker_sequence_assignments
+      plant_accessions
+      plant_lines
+      plant_parts
+      plant_populations
+      plant_scoring_units
+      plant_trials
+      population_loci
+      primers
+      processed_trait_datasets
+      qtl
+      qtl_jobs
+      scoring_occasions
+      trait_descriptors
+      trait_scores
+
+      plant_population_lists
+      plant_varieties
+      probes
+      trait_grades
+    )
+  end
+end

--- a/spec/controllers/data_tables_controller_spec.rb
+++ b/spec/controllers/data_tables_controller_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe DataTablesController do
       json = JSON.parse(response.body)
       expect(json['recordsTotal']).to eq 2
       expect(json['data'].size).to eq 2
-      expect(json['data'].map{ |pp| pp[-3] }).to match_array pps.map(&:id)
+      expect(json['data'].map(&:last)).to match_array pps.map(&:id)
     end
 
     it 'supports query filtering on json format request' do
@@ -58,7 +58,7 @@ RSpec.describe DataTablesController do
       json = JSON.parse(response.body)
       expect(json['recordsTotal']).to eq 1
       expect(json['data'].size).to eq 1
-      expect(json['data'][0][-3]).to eq pps[0]
+      expect(json['data'][0][-1]).to eq pps[0]
     end
 
     it 'prevents querying by unpermitted parameters' do

--- a/spec/decorators/application_decorator_spec.rb
+++ b/spec/decorators/application_decorator_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe ApplicationDecorator do
       gd = ApplicationDecorator.decorate(PlantPopulation.table_data)
       expect(gd.as_grid_data[:recordsTotal]).to eq 4
       expect(gd.as_grid_data[:data].size).to eq 4
-      expect(gd.as_grid_data[:data].map{ |pp| pp[-3] }).to match_array pps.map(&:id)
+      expect(gd.as_grid_data[:data].map(&:last)).to match_array pps.map(&:id)
     end
   end
 end

--- a/spec/factories/annotable.rb
+++ b/spec/factories/annotable.rb
@@ -1,0 +1,20 @@
+module AnnotableFactory
+  def self.annotated
+    Proc.new {
+      comments { Faker::Lorem.sentence }
+      entered_by_whom { Faker::Internet.user_name }
+      date_entered { Faker::Date.backward }
+      data_provenance { Faker::Lorem.sentence }
+      data_owned_by { Faker::Company.name }
+    }
+  end
+
+  def self.annotated_no_owner
+    Proc.new {
+      comments { Faker::Lorem.sentence }
+      entered_by_whom { Faker::Internet.user_name }
+      date_entered { Faker::Date.backward }
+      data_provenance { Faker::Lorem.sentence }
+    }
+  end
+end

--- a/spec/factories/plant_line.rb
+++ b/spec/factories/plant_line.rb
@@ -3,10 +3,7 @@ FactoryGirl.define do
     sequence(:plant_line_name) {|n| "#{Faker::Lorem.characters(5)}_#{n}"}
     common_name { Faker::Lorem.word }
     previous_line_name { Faker::Lorem.word }
-    date_entered { Faker::Date.backward }
-    data_owned_by { Faker::Company.name }
-    comments { Faker::Lorem.sentence }
-    data_provenance { Faker::Lorem.sentence }
     taxonomy_term
+    instance_eval &AnnotableFactory.annotated
   end
 end

--- a/spec/factories/plant_population.rb
+++ b/spec/factories/plant_population.rb
@@ -3,8 +3,8 @@ FactoryGirl.define do
     name { Faker::Lorem.word }
     canonical_population_name { Faker::Lorem.word }
     description { Faker::Lorem.sentence }
-    data_provenance { Faker::Lorem.sentence }
     taxonomy_term
     population_type
+    instance_eval &AnnotableFactory.annotated
   end
 end

--- a/spec/factories/plant_population_list.rb
+++ b/spec/factories/plant_population_list.rb
@@ -1,8 +1,6 @@
 FactoryGirl.define do
   factory :plant_population_list do
     sort_order '1'
-    comments { Faker::Lorem.sentence }
-    entered_by_whom { Faker::Internet.email }
-    data_provenance { Faker::Lorem.sentence }
+    instance_eval &AnnotableFactory.annotated_no_owner
   end
 end

--- a/spec/factories/plant_scoring_unit.rb
+++ b/spec/factories/plant_scoring_unit.rb
@@ -6,12 +6,8 @@ FactoryGirl.define do
     scoring_unit_frame_size { Faker::Number.number(2).to_s + ' plants in ' + Faker::Number.number(1).to_s }
     date_planted { Faker::Date.backward }
     described_by_whom { Faker::Internet.user_name }
-    comments { Faker::Lorem.sentence }
-    date_entered { Faker::Date.backward }
-    data_provenance { Faker::Lorem.sentence }
-    entered_by_whom { Faker::Internet.user_name }
     confirmed_by_whom { Faker::Internet.user_name }
-    data_owned_by { Faker::Company.name }
     plant_trial
+    instance_eval &AnnotableFactory.annotated
   end
 end

--- a/spec/factories/plant_trial.rb
+++ b/spec/factories/plant_trial.rb
@@ -2,18 +2,14 @@ FactoryGirl.define do
   factory :plant_trial do
     sequence(:plant_trial_name) {|n| "#{Faker::Lorem.characters(5)}_#{n}"}
     project_descriptor { Faker::Lorem.word }
-    date_entered { Faker::Date.backward }
-    comments { Faker::Lorem.sentence }
     trial_location_site_name { Faker::Lorem.sentence }
     place_name { Faker::Lorem.sentence }
     trial_year { Faker::Date.backward.year.to_s }
     plant_trial_description { Faker::Lorem.sentence }
-    data_provenance { Faker::Lorem.sentence }
-    entered_by_whom { Faker::Internet.user_name }
     contact_person { Faker::Internet.user_name }
     confirmed_by_whom { Faker::Internet.user_name }
-    data_owned_by { Faker::Company.name }
     country
     plant_population
+    instance_eval &AnnotableFactory.annotated
   end
 end

--- a/spec/factories/plant_variety.rb
+++ b/spec/factories/plant_variety.rb
@@ -2,13 +2,11 @@ FactoryGirl.define do
   factory :plant_variety do
     sequence(:plant_variety_name) {|n| "#{Faker::Lorem.characters(5)}_#{n}"}
     crop_type { Faker::Lorem.word }
-    comments { Faker::Lorem.sentence }
-    entered_by_whom { Faker::Internet.user_name }
-    date_entered { Date.today }
     year_registered { "2015" }
     breeders_variety_code { Faker::Lorem.word }
     owner { Faker::Company.name }
     female_parent { Faker::Lorem.word }
     male_parent { Faker::Lorem.word }
+    instance_eval &AnnotableFactory.annotated_no_owner
   end
 end

--- a/spec/factories/trait_descriptor.rb
+++ b/spec/factories/trait_descriptor.rb
@@ -16,11 +16,7 @@ FactoryGirl.define do
     likely_ambiguities { Faker::Lorem.sentence }
     contact_person { Faker::Internet.user_name }
     date_method_agreed { Faker::Date.backward }
-    comments { Faker::Lorem.sentence }
-    date_entered { Faker::Date.backward }
-    data_provenance { Faker::Lorem.sentence }
-    entered_by_whom { Faker::Internet.user_name }
     confirmed_by_whom { Faker::Internet.user_name }
-    data_owned_by { Faker::Company.name }
+    instance_eval &AnnotableFactory.annotated
   end
 end

--- a/spec/factories/trait_score.rb
+++ b/spec/factories/trait_score.rb
@@ -5,12 +5,8 @@ FactoryGirl.define do
     score_value { Faker::Number.number(10).to_s }
     score_spread { '' }
     value_type { Faker::Lorem.sentence }
-    comments { Faker::Lorem.sentence }
-    date_entered { Faker::Date.backward }
-    data_provenance { Faker::Lorem.sentence }
-    entered_by_whom { Faker::Internet.user_name }
     confirmed_by_whom { Faker::Internet.user_name }
-    data_owned_by { Faker::Company.name }
     plant_scoring_unit
+    instance_eval &AnnotableFactory.annotated
   end
 end

--- a/spec/models/concerns/annotable_spec.rb
+++ b/spec/models/concerns/annotable_spec.rb
@@ -1,0 +1,66 @@
+require 'rails_helper'
+
+RSpec.describe Annotable do
+  it 'makes sure all tables are instantiable as models' do
+    annotable_tables.each{ |t| t.singularize.camelize.constantize }
+  end
+
+  it 'provides rudimentary ref_columns set for all models' do
+    annotable_tables.each do |table|
+      klass = table.singularize.camelize.constantize
+      expect{ klass.ref_columns }.not_to raise_error
+      expect(klass.ref_columns.last).to eq "#{table}.id"
+    end
+  end
+
+  it 'makes sure all annotable models include this concern' do
+    no_factory = []
+    not_made_annotable = []
+    annotable_tables.each do |table|
+      begin
+        instance = create(table.singularize)
+        test_hash = {
+          'comments' => instance.comments,
+          'entered_by_whom' => instance.entered_by_whom,
+          'date_entered' => instance.date_entered,
+          'data_provenance' => instance.data_provenance
+        }.merge(
+          instance.has_attribute?('data_owned_by') ? { 'data_owned_by' => instance.data_owned_by } : {}
+        )
+        expect(instance.annotations_as_json).to eq test_hash
+        expect(test_hash.values.map(&:nil?)).to all be_falsey
+      rescue ArgumentError => e
+        no_factory << table.singularize
+      rescue NoMethodError => e
+        if e.message.include? 'annotations_as_json'
+          not_made_annotable << table.singularize
+        else
+          fail(e.message)
+        end
+      end
+    end
+
+    if no_factory.present?
+      pending "Factories for #{no_factory} not registered yet."
+    end
+
+    if not_made_annotable.present?
+      pending "#{not_made_annotable} should include Annotable"
+    end
+
+    fail if no_factory.present? || not_made_annotable.present?
+  end
+
+  context 'when model is Pluckable as well' do
+    it 'plucks at least the id column' do
+      annotable_tables.each do |table|
+        klass = table.singularize.camelize.constantize
+        if klass.ancestors.include? Pluckable
+          expect(klass.ref_columns.last).to eq "#{table}.id"
+          instances = create_list(table.singularize, 3)
+          expect(klass.pluck_columns.map(&:last)).to eq instances.map(&:id)
+        end
+      end
+    end
+  end
+end

--- a/spec/models/plant_line_spec.rb
+++ b/spec/models/plant_line_spec.rb
@@ -99,11 +99,10 @@ RSpec.describe PlantLine do
                   organisation: 'o',
                   plant_variety: pv)
 
-      plucked = PlantLine.pluck_columns(
-        PlantLine.table_columns + PlantLine.send(:ref_columns))
+      plucked = PlantLine.pluck_columns
       expect(plucked.count).to eq 1
       expect(plucked[0]).
-        to eq ['pln', 'tt', 'cn', 'pvn', 'ppln', de, 'dob', 'o', pv.id]
+        to eq ['pln', 'tt', 'cn', 'pvn', 'ppln', de, 'dob', 'o', pv.id, pl.id]
     end
   end
 

--- a/spec/models/plant_population_spec.rb
+++ b/spec/models/plant_population_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe PlantPopulation do
       gd = PlantPopulation.table_data
       expect(gd).not_to be_empty
       expect(gd.size).to eq 3
-      expect(gd.map{ |pp| pp[-4] }).to contain_exactly 2, 2, 0
+      expect(gd.map{ |pp| pp[6] }).to contain_exactly 2, 2, 0
     end
 
     it 'orders populations by population name' do
@@ -63,9 +63,12 @@ RSpec.describe PlantPopulation do
         fpl.plant_line_name,
         mpl.plant_line_name,
         pp.population_type.population_type,
-        0
+        0,
+        fpl.id,
+        mpl.id,
+        pp.id
       ]
-      expect(gd[0][0..-4]).to eq data
+      expect(gd[0]).to eq data
     end
   end
 end

--- a/spec/models/plant_trial_spec.rb
+++ b/spec/models/plant_trial_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe PlantTrial do
   describe '#pluckable' do
     it 'gets proper data table columns' do
       pt = create(:plant_trial)
-      plucked = PlantTrial.pluck_columns(PlantTrial.table_columns)
+      plucked = PlantTrial.pluck_columns
       expect(plucked.count).to eq 1
       expect(plucked[0]).
         to eq [
@@ -33,7 +33,8 @@ RSpec.describe PlantTrial do
           pt.plant_population.name,
           pt.trial_year,
           pt.trial_location_site_name,
-          pt.date_entered
+          pt.date_entered,
+          pt.id
         ]
     end
   end

--- a/spec/models/trait_descriptor_spec.rb
+++ b/spec/models/trait_descriptor_spec.rb
@@ -34,7 +34,8 @@ RSpec.describe TraitDescriptor do
         td.descriptor_name,
         td.trait_scores[0].plant_scoring_unit.plant_trial.project_descriptor,
         td.trait_scores[0].plant_scoring_unit.plant_trial.country.country_name,
-        1
+        1,
+        td.id
       ]
     end
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -6,6 +6,7 @@ require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
 require 'shoulda/matchers'
 require 'factory_girl_rails'
+require 'common_helpers'
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
@@ -52,6 +53,8 @@ RSpec.configure do |config|
 
   config.include FactoryGirl::Syntax::Methods
   config.include Warden::Test::Helpers, type: :request
+  config.include RSpecHtmlMatchers
+  include CommonHelpers
 end
 
 OmniAuth.config.test_mode = true

--- a/spec/views/data_tables/index.html.haml_spec.rb
+++ b/spec/views/data_tables/index.html.haml_spec.rb
@@ -3,8 +3,6 @@ require 'rails_helper'
 RSpec.describe 'data_tables/index.html.haml' do
   context 'when run for plant lines' do
     before(:each) do
-      allow(view).to receive(:controller_name).and_return('plant_lines')
-      allow(view).to receive(:action_name).and_return('index')
       allow(view).to receive(:params).and_return(model: 'plant_lines')
     end
 
@@ -19,6 +17,16 @@ RSpec.describe 'data_tables/index.html.haml' do
     it 'allows to go back to populations' do
       render
       expect(rendered).to include(data_tables_path(model: :plant_populations))
+    end
+  end
+
+  context 'when run for annotable models' do
+    it 'shows annotations column' do
+      annotable_tables.each do |table|
+        allow(view).to receive(:params).and_return(model: table)
+        render
+        expect(rendered).to have_tag('th.annotations')
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes #125 

For every model mentioned there (i.e. each one that contains those 4-5 generic columns):
 - the table data call is extended by a single (always last) column with the record id
 - that id is used to construct a link to data_tables_controller#show method
 - the method returns a json with those 4-5 field values
 - that json is fed into a simple popover.

This PR _does not_ provide a finished UI experience for this - it just leaves it in the stage that the data transfer is clearly visible yet the result is not presented to the user in any satisfactory way.