### PR TITLE
Search vs tables setup cleanup

### DIFF
--- a/app/assets/javascripts/data_grid.js.coffee
+++ b/app/assets/javascripts/data_grid.js.coffee
@@ -136,22 +136,22 @@ window.configs =
       ,
         targets: 'female_parent_line_column'
         render: (data, type, full, meta) ->
-          if data && full[7]
-            '<a href="data_tables?model=plant_lines&query[id]=' + full[7] + '">' + data + '</a>'
-          else
-            ''
-      ,
-        targets: 'male_parent_line_column'
-        render: (data, type, full, meta) ->
           if data && full[8]
             '<a href="data_tables?model=plant_lines&query[id]=' + full[8] + '">' + data + '</a>'
           else
             ''
       ,
+        targets: 'male_parent_line_column'
+        render: (data, type, full, meta) ->
+          if data && full[9]
+            '<a href="data_tables?model=plant_lines&query[id]=' + full[9] + '">' + data + '</a>'
+          else
+            ''
+      ,
         targets: 'plant_population_lists_count_column'
         render: (data, type, full, meta) ->
-          if data && data != '0' && full[9]
-            '<a href="data_tables?model=plant_lines&query[plant_populations.id]=' + full[9] + '">' + data + '</a>'
+          if data && data != '0' && full[10]
+            '<a href="data_tables?model=plant_lines&query[plant_populations.id]=' + full[10] + '">' + data + '</a>'
           else
             ''
       ]

--- a/app/models/plant_line.rb
+++ b/app/models/plant_line.rb
@@ -60,7 +60,7 @@ class PlantLine < ActiveRecord::Base
       'common_name',
       'plant_varieties.plant_variety_name',
       'previous_line_name',
-      'date_entered',
+      'genetic_status',
       'data_owned_by',
       'organisation'
     ]

--- a/app/models/plant_population.rb
+++ b/app/models/plant_population.rb
@@ -49,6 +49,7 @@ class PlantPopulation < ActiveRecord::Base
       'plant_lines.plant_line_name AS female_parent_line',
       'male_parent_lines_plant_populations.plant_line_name AS male_parent_line',
       'pop_type_lookup.population_type',
+      'description',
       'plant_population_lists_count'
     ]
   end
@@ -72,16 +73,16 @@ class PlantPopulation < ActiveRecord::Base
 
   def as_indexed_json(options = {})
     plant_line_attrs = [
-      :plant_line_name, :common_name, :genetic_status, :previous_line_name
+      :plant_line_name
     ]
 
     as_json(
       only: [
-        :id, :name, :canonical_population_name, :description,
-        :population_type
+        :id, :name, :canonical_population_name, :description
       ],
       include: {
         taxonomy_term: { only: [:name] },
+        population_type: { only: [:population_type] },
         female_parent_line: { only: plant_line_attrs },
         male_parent_line: { only: plant_line_attrs },
       }

--- a/config/locales/data_tables.en.yml
+++ b/config/locales/data_tables.en.yml
@@ -9,6 +9,7 @@ en:
       date_entered: Entry date
       data_owned_by: Data owner
       organisation: Organisation
+      genetic_status: Genetic status
     linkage_maps:
       linkage_map_label: Map label
       linkage_map_name: Map name
@@ -20,6 +21,7 @@ en:
       female_parent_line: Female parent line
       male_parent_line: Male parent line
       plant_population_lists_count: Plant lines
+      description: Description
     plant_trials:
       plant_trial_name: Name
       plant_trial_description: Trial

--- a/spec/common_helpers.rb
+++ b/spec/common_helpers.rb
@@ -37,4 +37,11 @@ module CommonHelpers
       model_klass.respond_to? :table_columns
     end
   end
+
+  def searchable_models
+    Rails.application.eager_load!
+    ActiveRecord::Base.descendants.select do |model|
+      model.included_modules.include? Elasticsearch::Model
+    end
+  end
 end

--- a/spec/factories/plant_line.rb
+++ b/spec/factories/plant_line.rb
@@ -1,8 +1,10 @@
 FactoryGirl.define do
   factory :plant_line do
-    sequence(:plant_line_name) {|n| "#{Faker::Lorem.characters(5)}_#{n}"}
-    common_name { Faker::Lorem.word }
-    previous_line_name { Faker::Lorem.word }
+    sequence(:plant_line_name) { |n| "#{Faker::Lorem.characters(5)}_#{n}" }
+    common_name Faker::Lorem.word
+    previous_line_name Faker::Lorem.word
+    organisation Faker::Company.name
+    genetic_status Faker::Lorem.word
     taxonomy_term
     annotable
   end

--- a/spec/factories/plant_population.rb
+++ b/spec/factories/plant_population.rb
@@ -1,8 +1,10 @@
 FactoryGirl.define do
   factory :plant_population do
-    name { Faker::Lorem.word }
-    canonical_population_name { Faker::Lorem.word }
-    description { Faker::Lorem.sentence }
+    name Faker::Lorem.word
+    canonical_population_name Faker::Lorem.word
+    description Faker::Lorem.sentence
+    male_parent_line { create(:plant_line) }
+    female_parent_line { create(:plant_line) }
     taxonomy_term
     population_type
     annotable

--- a/spec/models/concerns/annotable_spec.rb
+++ b/spec/models/concerns/annotable_spec.rb
@@ -57,6 +57,7 @@ RSpec.describe Annotable do
         klass = table.singularize.camelize.constantize
         if klass.ancestors.include? Pluckable
           expect(klass.ref_columns.last).to eq "#{table}.id"
+          klass.destroy_all
           instances = create_list(table.singularize, 3)
           expect(klass.pluck_columns.map(&:last)).
             to match_array instances.map(&:id)

--- a/spec/models/model_spec.rb
+++ b/spec/models/model_spec.rb
@@ -23,11 +23,15 @@ RSpec.describe ActiveRecord::Base do
 
   context 'when model supports elastic search' do
     before(:all) do
-      @searchable = searchable_models
+      @searchables = searchable_models
+    end
+
+    it 'ensures searchable_models helper do not make fools of us' do
+      expect(@searchables).not_to be_empty
     end
 
     it 'makes sure all basic searchable fields are displayed in tables' do
-      @searchable.each do |searchable|
+      @searchables.each do |searchable|
         instance = create(searchable)
         instance.send(:as_indexed_json).each do |k,v|
           next if k == 'id'

--- a/spec/models/model_spec.rb
+++ b/spec/models/model_spec.rb
@@ -1,5 +1,13 @@
 require 'rails_helper'
 
+RSpec::Matchers.define :display_column do |expected|
+  match do |actual|
+    actual.any? do |column|
+      column.include?(expected)
+    end
+  end
+end
+
 RSpec.describe ActiveRecord::Base do
   it 'defines table and ref columns as strings only' do
     Rails.application.eager_load!
@@ -9,6 +17,30 @@ RSpec.describe ActiveRecord::Base do
       end
       if model.respond_to? 'ref_columns'
         expect(model.ref_columns).to all be_an(String)
+      end
+    end
+  end
+
+  context 'when model supports elastic search' do
+    before(:all) do
+      @searchable = searchable_models
+    end
+
+    it 'makes sure all basic searchable fields are displayed in tables' do
+      @searchable.each do |searchable|
+        instance = create(searchable)
+        instance.send(:as_indexed_json).each do |k,v|
+          next if k == 'id'
+          if v.instance_of? Hash
+            v.each do |column,_|
+              expect(searchable.table_columns).
+                to display_column(instance.send(k).class.table_name + '.' + column)
+            end
+          else
+            expect(searchable.table_columns).
+              to display_column(k).or display_column(searchable.table_name + '.' + k)
+          end
+        end
       end
     end
   end

--- a/spec/models/plant_line_spec.rb
+++ b/spec/models/plant_line_spec.rb
@@ -87,35 +87,35 @@ RSpec.describe PlantLine do
 
   describe '#pluckable' do
     it 'gets proper data table columns' do
-      tt = create(:taxonomy_term, name: 'tt')
-      pv = create(:plant_variety, plant_variety_name: 'pvn')
-      de = Date.today
-      pl = create(:plant_line,
-                  plant_line_name: 'pln',
-                  taxonomy_term: tt,
-                  common_name: 'cn',
-                  previous_line_name: 'ppln',
-                  date_entered: de,
-                  data_owned_by: 'dob',
-                  organisation: 'o',
-                  plant_variety: pv)
+      pl = create(:plant_line, plant_variety: create(:plant_variety))
 
       plucked = PlantLine.pluck_columns
       expect(plucked.count).to eq 1
-      expect(plucked[0]).
-        to eq ['pln', 'tt', 'cn', 'pvn', 'ppln', de, 'dob', 'o', pv.id, pl.id]
+      expect(plucked[0]).to eq [
+        pl.plant_line_name,
+        pl.taxonomy_term.name,
+        pl.common_name,
+        pl.plant_variety.plant_variety_name,
+        pl.previous_line_name,
+        pl.genetic_status,
+        pl.data_owned_by,
+        pl.organisation,
+        pl.plant_variety.id,
+        pl.id
+      ]
     end
   end
 
   describe '#table_data' do
     it 'returns empty result when no plant lines found' do
-      expect(PlantLine.table_data(plant_line_names: 1)).to be_empty
+      expect(PlantLine.table_data({})).to be_empty
     end
 
-    # it 'orders plant lines by plant line name' do
-    #   plids = create_list(:plant_line, 3).map(&:id)
-    #   td = PlantLine.table_data(query: { id: plids })
-    #   expect(td.map(&:first)).to eq plids.sort
-    # end
+    it 'orders plant lines by plant line name' do
+      pp = create(:plant_population)
+      pls = create_list(:plant_line, 3, plant_populations: [pp])
+      td = PlantLine.table_data(query: { 'plant_populations.id': pp.id })
+      expect(td.map(&:first)).to eq pls.map(&:plant_line_name).sort
+    end
   end
 end

--- a/spec/models/plant_population_spec.rb
+++ b/spec/models/plant_population_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe PlantPopulation do
       gd = PlantPopulation.table_data
       expect(gd).not_to be_empty
       expect(gd.size).to eq 3
-      expect(gd.map{ |pp| pp[6] }).to contain_exactly 2, 2, 0
+      expect(gd.map{ |pp| pp[7] }).to contain_exactly 2, 2, 0
     end
 
     it 'orders populations by population name' do
@@ -63,6 +63,7 @@ RSpec.describe PlantPopulation do
         fpl.plant_line_name,
         mpl.plant_line_name,
         pp.population_type.population_type,
+        pp.description,
         0,
         fpl.id,
         mpl.id,


### PR DESCRIPTION
Fixes some issues with the current ES setup in PlantPopulation.

Makes sure all ES-searchable fields are displayed in DataTables so a user is not confused why a given record was found in response to her query.

Fixes #173 