### PR TITLE
Better submission validation

### DIFF
--- a/app/assets/javascripts/submissions.coffee
+++ b/app/assets/javascripts/submissions.coffee
@@ -19,7 +19,7 @@ class Submission
 
   defaultSelectOptions: { allowClear: true }
   plantLineSelectOptions: @makeAjaxSelectOptions('/plant_lines', 'plant_line_name')
-  plantLineListSelectOptions: $.extend({}, @plantLineSelectOptions, multiple: true)
+  plantLineListSelectOptions: $.extend(@makeAjaxSelectOptions('/plant_lines', 'plant_line_name'), multiple: true)
   plantVarietySelectOptions: @makeAjaxSelectOptions('/plant_varieties', 'plant_variety_name')
 
   constructor: (el) ->

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -9,7 +9,7 @@ class SubmissionsController < ApplicationController
   def show
     submission = current_user.submissions.find(params[:id])
     @submission = PlantPopulationSubmissionDecorator.decorate(submission)
- end
+  end
 
   def edit
     @submission = current_user.submissions.find(params[:id])

--- a/app/forms/submissions/step01_content_form.rb
+++ b/app/forms/submissions/step01_content_form.rb
@@ -5,5 +5,11 @@ module Submissions
     property :owned_by
 
     validates :name, presence: true
+
+    validate do
+      if PlantPopulation.where(name: name).exists?
+        errors.add(:name, :taken)
+      end
+    end
   end
 end

--- a/app/forms/submissions/step03_content_form.rb
+++ b/app/forms/submissions/step03_content_form.rb
@@ -28,7 +28,7 @@ module Submissions
     validate do
       new_plant_lines.each do |new_plant_line|
         if plant_line_exists?(new_plant_line.plant_line_name)
-          errors.add(:new_plant_lines, "#{new_plant_line.plant_line_name} already exists in our database")
+          errors.add(:new_plant_line, "#{new_plant_line.plant_line_name} already exists in our database")
         end
       end
     end

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -42,13 +42,14 @@ class Submission < ActiveRecord::Base
     step == STEPS.last
   end
 
+  def reset_step
+    self.step = STEPS[0]
+    save!
+  end
+
   def finalize
     raise CantFinalize unless last_step?
-    transaction do
-      PlantPopulationFinalizer.new(self).call
-      self.finalized = true
-      save!
-    end
+    PlantPopulationFinalizer.new(self).call
   end
 
   def submitted_object

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -127,18 +127,6 @@ RSpec.describe Submission do
       allow_any_instance_of(Submission::PlantPopulationFinalizer).to receive(:call)
     end
 
-    it 'ensures presence of submitted object upon finalization' do
-      submission.update_attribute(:step, submission.steps.last)
-      expect { submission.finalize }.
-        to raise_error ActiveRecord::RecordInvalid
-    end
-
-    it 'updated submission' do
-      submission.update_attribute(:step, submission.steps.last)
-      submission.update_attribute(:submitted_object_id, 1)
-      expect { submission.finalize }.to change { submission.finalized? }.from(false).to(true)
-    end
-
     it 'calls finalizer' do
       expect_any_instance_of(Submission::PlantPopulationFinalizer).to receive(:call)
       submission.update_attribute(:step, submission.steps.last)


### PR DESCRIPTION
Partially fixes #277 

1. Validates PP#name uniqueness in first step
2. Validates PP#name uniqueness in finalizer and redirects to the beginning if PP already exists
3. Bonus: fixes initialization of PLL select (it should be cherry picked to master in case this branch is not merged)

Nothing is done for new PLs yet, but:
 
* PL#plant_line_name validation in form was already implemented
* before changing validation in finalizer we need to decide how to present this error to the user

 