### PR TITLE
Create api improvements

### DIFF
--- a/app/controllers/api/v1/resources_controller.rb
+++ b/app/controllers/api/v1/resources_controller.rb
@@ -24,7 +24,13 @@ class Api::V1::ResourcesController < ApplicationController
   end
 
   def create
-    resource = model_klass.new(create_params.merge(:user_id => api_key.user_id))
+    resource = model_klass.new(
+      create_params.merge(
+        :user_id => api_key.user_id,
+        :date_entered => Date.today,
+        :entered_by_whom => api_key.user.full_name
+      )
+    )
 
     if resource.save
       render json: { model_name => decorate(resource) }, status: :created
@@ -103,7 +109,7 @@ class Api::V1::ResourcesController < ApplicationController
   end
 
   def create_params
-    blacklisted_attrs = %w(id user_id created_at updated_at)
+    blacklisted_attrs = %w(id user_id created_at updated_at date_entered entered_by_whom)
     model_attrs = model_klass.attribute_names
     permitted_attrs =  model_attrs - blacklisted_attrs
 

--- a/app/controllers/api/v1/resources_controller.rb
+++ b/app/controllers/api/v1/resources_controller.rb
@@ -53,7 +53,11 @@ class Api::V1::ResourcesController < ApplicationController
       return
     end
     unless api_key.present?
-      render json: '{"reason": "Invalid API key"}', status: 401
+      if api_key_token == I18n.t('api.general.demo_key')
+        render json: '{"reason": "Please use your own, personal API key"}', status: 401
+      else
+        render json: '{"reason": "Invalid API key"}', status: 401
+      end
     end
   end
 

--- a/app/controllers/api/v1/resources_controller.rb
+++ b/app/controllers/api/v1/resources_controller.rb
@@ -2,6 +2,8 @@
 class Api::V1::ResourcesController < ApplicationController
   include Pagination
 
+  protect_from_forgery with: :null_session
+
   before_filter :authenticate_api_key!
   before_filter :require_allowed_model
   before_filter :require_strictly_correct_params, only: :create

--- a/app/controllers/api/v1/resources_controller.rb
+++ b/app/controllers/api/v1/resources_controller.rb
@@ -49,12 +49,11 @@ class Api::V1::ResourcesController < ApplicationController
 
   def authenticate_api_key!
     unless api_key_token.present?
-      render text: "Unauthorized\n\nBIP API requires API key authentication", status: 401
+      render json: '{"reason": "BIP API requires API key authentication"}', status: 401
       return
     end
     unless api_key.present?
-      render text: "Unauthorized\n\nInvalid API key", status: 401
-      return
+      render json: '{"reason": "Invalid API key"}', status: 401
     end
   end
 

--- a/app/services/api.rb
+++ b/app/services/api.rb
@@ -17,6 +17,7 @@ class Api
       PlantTrial,
       PlantVariety,
       PopulationLocus,
+      PopulationType,
       Primer,
       Probe,
       Qtl,

--- a/app/views/application/api.html.haml
+++ b/app/views/application/api.html.haml
@@ -176,6 +176,16 @@
 
       = api_props('Default attribute values', 'general.create.default_attribute_values')
 
+      %p
+        Finally, one does not set attributes marked as <code>readonly</code> in the attribute
+        tables (one such example is attribute <code>population_type</code> of Plant Population).
+        Instead, one should assign a BIP identifier of such a related object when submitting
+        new data. For instance, when submitting a new Plant Population:
+
+      %h4 Example
+      %pre.response
+        %code= t('api.general.create.examples.wrong_vs_right_related_object')
+
 
       -# Models section follows
 

--- a/app/views/application/api.html.haml
+++ b/app/views/application/api.html.haml
@@ -102,6 +102,10 @@
       %pre.response
         %code= t('api.pagination.response')
 
+      %p
+        <strong>Remember</strong>, you should replace the <code>X-BIP-Api-Key</code> value
+        with your own API Key.
+
 
       %h3#filtering-data.section-heading Filtering data
 

--- a/app/views/application/api.html.haml
+++ b/app/views/application/api.html.haml
@@ -9,6 +9,7 @@
           %li= link_to "Fetching data", "#fetching-data"
           %li= link_to "Filtering data", "#filtering-data"
           %li= link_to "Searching for data", "#searching-for-data"
+          %li= link_to "Submitting data", "#submitting-data"
 
           - Api.models.each do |model|
             %li= link_to model.name, "##{model.name.underscore.dasherize}"
@@ -37,7 +38,6 @@
         - Api.writable_models.each do |model|
           %li= model.name
 
-      -# FIXME verify and describe date format
       %p
         All attributes are expressed as basic data types such as <code>int</code>,
         <code>string</code>, <code>date</code> or arrays of these. Most of the related
@@ -54,25 +54,7 @@
       %pre.response
         %code= t('api.general.create.examples.ok_response')
 
-      %p
-        For each resource there are attributes (described later) required
-        for create requests. Skipping any of those will result in an
-        <code>422</code> error response. Passing attributes which are not recognized by the API will also
-        result in <code>422</code> error response.
-
-      %h4 Examples
-      %ol
-        %li
-          %p Missing value for required attribute
-          %pre.response
-            %code= t('api.general.create.examples.missing_required_attrs_response')
-
-        %li
-          %p Misspelled attribute name
-          %pre.response
-            %code= t('api.general.create.examples.unknown_attrs_response')
-
-      %p Several other resources allow for fetching data only:
+      %p Several resources allow for fetching data only:
 
       %ul
         - Api.readonly_models.each do |model|
@@ -138,6 +120,61 @@
       %p
         Similar generic section about how to issue full-text search calls to
         BIP, how to adjust scope (model), what to expect as the outcome
+
+
+      %h3#submitting-data.section-heading Submitting new data
+
+      %p
+        Currently one is able to submit the following resources via API:
+
+      %ul
+        - Api.writable_models.each do |model|
+          %li= model.name
+
+      %p
+        Data submission is based on JSON format. That is, the API <code>POST</code>
+        request should pass a JSON document in its post data, where the most important
+        element is called as the resource itself (e.g. <code>plant_population</code>).
+        Each resource section below show an example of such a <code>POST</code> API call.
+
+      %p
+        For each resource there are attributes (described later) required
+        for create requests. Skipping any of those will result in an
+        <code>422</code> error response. Passing attributes which are not recognized by the API will also
+        result in <code>422</code> error response.
+
+      %h4 Examples
+      %ol
+        %li
+          %p Missing value for required attribute
+          %pre.response
+            %code= t('api.general.create.examples.missing_required_attrs_response')
+
+        %li
+          %p Misspelled attribute name
+          %pre.response
+            %code= t('api.general.create.examples.unknown_attrs_response')
+
+      %p
+        Most of the resource attributes, as shown in the following attribute tables,
+        are text (<code>string</code> format) - these are simply pieces of text of
+        arbitrary length, enclosed in double quote marks <code>"</code>. Attributes
+        that are of <code>int</code> format are passed without quotes.
+
+      %p
+        Dates should be delivered in textual format - several different notations are
+        acceptable and will be recognized, but we advise to stick to a single, consistent
+        format of <code>YYYY-MM-DD</code>. Examples are given below:
+
+      %h4 Example
+      %pre.response
+        %code= t('api.general.create.examples.attribute_value_samples')
+
+      %p
+        Two attributes are never set by submitting users, but are rather automatically
+        set by the server:
+
+      = api_props('Default attribute values', 'general.create.default_attribute_values')
 
 
       -# Models section follows

--- a/config/locales/api.en.yml
+++ b/config/locales/api.en.yml
@@ -1370,3 +1370,26 @@ en:
         params:
           -
             name: "???"
+
+    population_type:
+      attrs:
+        -
+          name: id
+        -
+          name: population_type
+          desc: The textual description of the population type
+        -
+          name: population_class
+          desc: What class of populations that type belong to
+        -
+          name: assigned_by_whom
+          desc: The name of the popultion type assigning party
+        -
+          name: plant_populations_ids
+          format: "int[]"
+          desc: Zero or more of BIP identifiers of Plant Populations that are of this population type
+
+      index:
+        params:
+          -
+            name: "???"

--- a/config/locales/api.en.yml
+++ b/config/locales/api.en.yml
@@ -10,12 +10,16 @@ en:
             Content-Type: application/json; charset=utf-8
 
             {
-              "plant_variety": {
+              "plant_population": {
                 "id": 1,
-                "plant_variety_name": "0068",
-                "crop_type": "oilseed rape",
+                "name": "BnaWAIT_01",
+                "population_type": {
+                  "population_type": "Integrated",
+                  "population_class": "Mapping",
+                  ...
+                },
                 ...
-                "plant_lines_ids": [10792]
+                "linkage_maps_ids": [8]
               }
             }
 
@@ -38,6 +42,28 @@ en:
                 { "attribute": "priner", "message": "Unrecognized attribute name" }
               ]
             }
+
+          attribute_value_samples: |-
+            {
+              "plant_population": {
+                ...
+                "description": "Example of text content",
+                "date_established": "2015-05-30",
+                "taxonomy_term_id": 5,
+                ...
+              }
+            }
+
+        default_attribute_values:
+          -
+            name: entered_by_whom
+            format: string
+            desc: Always set to the user name of whomever API Key was used to submit the data.
+          -
+            name: date_entered
+            format: date
+            desc: Always set to the day the data was successfully submitted.
+
 
     filtering:
       params:

--- a/config/locales/api.en.yml
+++ b/config/locales/api.en.yml
@@ -35,7 +35,7 @@ en:
 
             {
               "errors": [
-                { "attribute": "nmae", "message": "Unrecognized attribute name" }
+                { "attribute": "priner", "message": "Unrecognized attribute name" }
               ]
             }
 

--- a/config/locales/api.en.yml
+++ b/config/locales/api.en.yml
@@ -54,6 +54,17 @@ en:
               }
             }
 
+          wrong_vs_right_related_object: |-
+            {
+              "plant_population": {
+                ...
+                "population_type": "DH segregating",  # WRONG
+                "population_type_id": 1,  # RIGHT
+                ...
+              }
+            }
+
+
         default_attribute_values:
           -
             name: entered_by_whom
@@ -270,7 +281,7 @@ en:
           name: data_owned_by
         -
           name: population_type
-          format: object
+          format: object, readonly
           desc: Additional information about the type of this population
         -
           name: description
@@ -302,6 +313,10 @@ en:
           name: confirmed_by_whom
         -
           name: taxonomy_term_id
+        -
+          name: population_type_id
+          format: int
+          desc: BIP identifier of the Population Type assigned to this population
         -
           name: male_parent_line_id
           format: int

--- a/config/locales/api.en.yml
+++ b/config/locales/api.en.yml
@@ -1,6 +1,8 @@
 en:
   api:
     general:
+      demo_key: ba6d4625927ede0db8768782994d9276cfff9ba79e8df8c831aedc453e850836
+
       create:
         examples:
           ok_response: |-

--- a/spec/services/search_spec.rb
+++ b/spec/services/search_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Search, :elasticsearch, :dont_clean_db do
     create(:plant_variety, plant_variety_name: "Pvoobar")
     create(:plant_variety, plant_variety_name: "Pvoobarbaz")
 
-    create(:plant_line, plant_line_name: "Ploo",
+    create(:plant_line, plant_line_name: "Ploob",
                         common_name: "Ploo cabbage",
                         taxonomy_term: TaxonomyTerm.first)
     create(:plant_line, plant_line_name: "Ploobar",
@@ -149,10 +149,7 @@ RSpec.describe Search, :elasticsearch, :dont_clean_db do
     end
 
     it "finds PL by fragment of :plant_line_name" do
-      result = Search.new("lo").plant_lines.select do |pl|
-        pl.plant_line_name.include? 'lo'
-      end
-      expect(result.count).to eq 3
+      expect(Search.new("loo").plant_lines.count).to eq 3
       expect(Search.new("looba").plant_lines.count).to eq 2
       expect(Search.new("loobarba").plant_lines.count).to eq 1
       expect(Search.new("loobarbaz").plant_lines.first.id.to_i).

--- a/spec/support/shared_examples/api_readable_resource.rb
+++ b/spec/support/shared_examples/api_readable_resource.rb
@@ -23,7 +23,7 @@ RSpec.shared_examples "API-readable resource" do |model_klass|
 
   context "with invalid api key" do
     describe "GET /api/v1/#{model_name.pluralize}" do
-      it "returns 403" do
+      it "returns 401" do
         get "/api/v1/#{model_name.pluralize}", {}, { "X-BIP-Api-Key" => "invalid" }
 
         expect(response.status).to eq 401
@@ -33,7 +33,7 @@ RSpec.shared_examples "API-readable resource" do |model_klass|
     describe "GET /api/v1/#{model_name.pluralize}/:id" do
       let!(:resource) { create model_name }
 
-      it "returns 403" do
+      it "returns 401" do
         get "/api/v1/#{model_name.pluralize}/#{resource.id}", {}, { "X-BIP-Api-Key" => "invalid" }
 
         expect(response.status).to eq 401

--- a/spec/support/shared_examples/api_readable_resource.rb
+++ b/spec/support/shared_examples/api_readable_resource.rb
@@ -25,12 +25,21 @@ RSpec.shared_examples "API-readable resource" do |model_klass|
   end
 
   context "with invalid api key" do
+    let(:demo_key) { I18n.t('api.general.demo_key') }
+
     describe "GET /api/v1/#{model_name.pluralize}" do
       it "returns 401" do
         get "/api/v1/#{model_name.pluralize}", {}, { "X-BIP-Api-Key" => "invalid" }
 
         expect(response.status).to eq 401
         expect(parsed_response['reason']).not_to be_empty
+      end
+
+      it "shows gentle reminder if one is using demo key" do
+        get "/api/v1/#{model_name.pluralize}", {}, { "X-BIP-Api-Key" => demo_key }
+
+        expect(response.status).to eq 401
+        expect(parsed_response['reason']).to eq "Please use your own, personal API key"
       end
     end
 

--- a/spec/support/shared_examples/api_readable_resource.rb
+++ b/spec/support/shared_examples/api_readable_resource.rb
@@ -1,5 +1,6 @@
 RSpec.shared_examples "API-readable resource" do |model_klass|
   model_name = model_klass.name.underscore
+  let(:parsed_response) { JSON.parse(response.body) }
 
   context "with no api key" do
     describe "GET /api/v1/#{model_name.pluralize}" do
@@ -7,6 +8,7 @@ RSpec.shared_examples "API-readable resource" do |model_klass|
         get "/api/v1/#{model_name.pluralize}"
 
         expect(response.status).to eq 401
+        expect(parsed_response['reason']).not_to be_empty
       end
     end
 
@@ -17,6 +19,7 @@ RSpec.shared_examples "API-readable resource" do |model_klass|
         get "/api/v1/#{model_name.pluralize}/#{resource.id}"
 
         expect(response.status).to eq 401
+        expect(parsed_response['reason']).not_to be_empty
       end
     end
   end
@@ -27,6 +30,7 @@ RSpec.shared_examples "API-readable resource" do |model_klass|
         get "/api/v1/#{model_name.pluralize}", {}, { "X-BIP-Api-Key" => "invalid" }
 
         expect(response.status).to eq 401
+        expect(parsed_response['reason']).not_to be_empty
       end
     end
 
@@ -37,13 +41,13 @@ RSpec.shared_examples "API-readable resource" do |model_klass|
         get "/api/v1/#{model_name.pluralize}/#{resource.id}", {}, { "X-BIP-Api-Key" => "invalid" }
 
         expect(response.status).to eq 401
+        expect(parsed_response['reason']).not_to be_empty
       end
     end
   end
 
   context "with valid api key" do
     let(:api_key) { create(:api_key) }
-    let(:parsed_response) { JSON.parse(response.body) }
 
     describe "GET /api/v1/#{model_name.pluralize}" do
       describe "response" do

--- a/spec/support/shared_examples/api_writable_resource.rb
+++ b/spec/support/shared_examples/api_writable_resource.rb
@@ -1,5 +1,6 @@
 RSpec.shared_examples "API-writable resource" do |model_klass|
   model_name = model_klass.name.underscore
+  let(:parsed_response) { JSON.parse(response.body) }
 
   context "with no api key" do
     describe "POST /api/v1/#{model_name.pluralize}" do
@@ -7,6 +8,7 @@ RSpec.shared_examples "API-writable resource" do |model_klass|
         get "/api/v1/#{model_name.pluralize}"
 
         expect(response.status).to eq 401
+        expect(parsed_response['reason']).not_to be_empty
       end
     end
   end
@@ -17,13 +19,13 @@ RSpec.shared_examples "API-writable resource" do |model_klass|
         get "/api/v1/#{model_name.pluralize}", {}, { "X-BIP-Api-Key" => "invalid" }
 
         expect(response.status).to eq 401
+        expect(parsed_response['reason']).not_to be_empty
       end
     end
   end
 
   context "with valid api key" do
     let(:api_key) { create(:api_key) }
-    let(:parsed_response) { JSON.parse(response.body) }
 
     let(:required_attrs) { required_attributes(model_klass) - [:user]}
 

--- a/spec/support/shared_examples/api_writable_resource.rb
+++ b/spec/support/shared_examples/api_writable_resource.rb
@@ -14,12 +14,21 @@ RSpec.shared_examples "API-writable resource" do |model_klass|
   end
 
   context "with invalid api key" do
+    let(:demo_key) { I18n.t('api.general.demo_key') }
+
     describe "POST /api/v1/#{model_name.pluralize}" do
       it "returns 401" do
         get "/api/v1/#{model_name.pluralize}", {}, { "X-BIP-Api-Key" => "invalid" }
 
         expect(response.status).to eq 401
         expect(parsed_response['reason']).not_to be_empty
+      end
+
+      it "shows gentle reminder if one is using demo key" do
+        get "/api/v1/#{model_name.pluralize}", {}, { "X-BIP-Api-Key" => demo_key }
+
+        expect(response.status).to eq 401
+        expect(parsed_response['reason']).to eq "Please use your own, personal API key"
       end
     end
   end


### PR DESCRIPTION
Some further improvements in the create API:
 - switched from session auth to key based auth
 - returns json instead of text for 40x messages
 - rebuilt api docs with separate section on data submission
 - other smaller things.
