### PR TITLE
Fixes duplicate records in pv <> country linking tables

### DIFF
--- a/db/migrate/20150625113612_add_unique_indices_to_pv_country_tables.rb
+++ b/db/migrate/20150625113612_add_unique_indices_to_pv_country_tables.rb
@@ -1,0 +1,23 @@
+class AddUniqueIndicesToPvCountryTables < ActiveRecord::Migration
+  def up
+    # Scan existing table and purge excess records
+    # Temporarily add a PK to pv_coo and pv_cr
+    add_column :plant_variety_country_of_origin, :id, :primary_key
+    add_column :plant_variety_country_registered, :id, :primary_key
+    execute "DELETE FROM plant_variety_country_of_origin WHERE id NOT IN \
+      (SELECT MIN(id) FROM plant_variety_country_of_origin GROUP BY country_id, plant_variety_id);"
+    execute "DELETE FROM plant_variety_country_registered WHERE id NOT IN \
+      (SELECT MIN(id) FROM plant_variety_country_registered GROUP BY country_id, plant_variety_id);"
+    # Remove the now-useless PKs
+    remove_column :plant_variety_country_of_origin, :id
+    remove_column :plant_variety_country_registered, :id
+
+    add_index(:plant_variety_country_of_origin, [:plant_variety_id, :country_id], unique: true, name: 'unique_pv_coo_idx')
+    add_index(:plant_variety_country_registered, [:plant_variety_id, :country_id], unique: true, name: 'unique_pv_cr_idx')
+  end
+
+  def down
+    remove_index(:plant_variety_country_of_origin, name: 'unique_pv_coo_idx')
+    remove_index(:plant_variety_country_registered, name: 'unique_pv_cr_idx')
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150625104617) do
+ActiveRecord::Schema.define(version: 20150625113612) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -413,6 +413,7 @@ ActiveRecord::Schema.define(version: 20150625104617) do
   end
 
   add_index "plant_variety_country_of_origin", ["country_id"], name: "plant_variety_country_of_origin_country_id_idx", using: :btree
+  add_index "plant_variety_country_of_origin", ["plant_variety_id", "country_id"], name: "unique_pv_coo_idx", unique: true, using: :btree
   add_index "plant_variety_country_of_origin", ["plant_variety_id"], name: "plant_variety_country_of_origin_plant_variety_id_idx", using: :btree
 
   create_table "plant_variety_country_registered", id: false, force: :cascade do |t|
@@ -421,6 +422,7 @@ ActiveRecord::Schema.define(version: 20150625104617) do
   end
 
   add_index "plant_variety_country_registered", ["country_id"], name: "plant_variety_country_registered_country_id_idx", using: :btree
+  add_index "plant_variety_country_registered", ["plant_variety_id", "country_id"], name: "unique_pv_cr_idx", unique: true, using: :btree
   add_index "plant_variety_country_registered", ["plant_variety_id"], name: "plant_variety_country_registered_plant_variety_id_idx", using: :btree
 
   create_table "pop_type_lookup", force: :cascade do |t|


### PR DESCRIPTION
Also prevents further duplication of records in `plant_variety_country_of_origin` and `plant_variety_country_registered`.