### PR TITLE
fixed search history management for safari

### DIFF
--- a/app/assets/javascripts/application.coffee
+++ b/app/assets/javascripts/application.coffee
@@ -38,7 +38,12 @@ $ ->
     bottom: ->
       return @bottom = - bh.top + 320
 
-#  # Handles navigation through history states originating from client-side
-#  # (e.g. search results)
-#  $(window).on 'popstate', ->
-#    window.location.replace window.location.href
+  # Handles navigation through history states originating from client-side
+  # (e.g. search results)
+  if window.isSafari()
+    $(window).on 'popstate', (e) ->
+      if e.originalEvent.state != null
+        window.location.replace window.location.href
+  else
+    $(window).on 'popstate', ->
+      window.location.replace window.location.href

--- a/app/assets/javascripts/search.coffee
+++ b/app/assets/javascripts/search.coffee
@@ -50,7 +50,7 @@ class Search
 
   updateHistory: (term) =>
     if window.location.search != "?search=#{term}"
-      window?.history?.pushState(null, null, "/?search=#{term}")
+      window?.history?.pushState({ cause: 'search' }, null, "/?search=#{term}")
 
 $ ->
   new Search('.search', '.search-results', '.search-example').prepare()


### PR DESCRIPTION
Fixes #357 

Done by assigning a state object to the pushState call and checking that object presence in the popstate handler. Also preserving old code for non-Safari browsers.