### PR TITLE
Simple rails cache for DT jsons

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -11,7 +11,8 @@ Rails.application.configure do
 
   # Show full error reports and disable caching.
   config.consider_all_requests_local       = true
-  config.action_controller.perform_caching = false
+  # config.action_controller.perform_caching = false
+  config.action_controller.perform_caching = true
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false


### PR DESCRIPTION
Tomasz, this is a new PR to discuss and co-develop data table creation and transfer optimization.

What I pushed is a simple rails cache mechanism to store jsons ready to be shipped to the client. The cache key is based on entire model count and the model-wide latest updated_at, so it should be error-proof. It is valid infinitely so given appropriate auto-outdating strategy we may set it a very long expiration date (or do I miss sth important here?).

For all plant lines is makes >10x faster data retrieval and preparation on my localhost (this, however, does not tackle the problem of data transfer and rendering). What is nice is that is works for all clients (so coming second you already hit the cache on you first pare visit). Any submission and deletion should make the cache MISSED for the first time.

TODOs:
- [x] check what old cache purge strategy the in-memory rails cache has and if we need an external service (like memcached) for that or not
- [ ] after everything is done and tested, we may revert "perform_caching = true" in the development mode (thought it is not strictly required to remove it).

I'm keen to know you opinion about that (and what other optimization strategies you see fit for our case).