### PR TITLE
Add rake task cache:cleanup

### DIFF
--- a/lib/tasks/cache.rake
+++ b/lib/tasks/cache.rake
@@ -1,0 +1,6 @@
+namespace :cache do
+  desc "Remove expired cache entries"
+  task cleanup: :environment do
+    Rails.cache.cleanup
+  end
+end


### PR DESCRIPTION
It seems RoR does not have anything like this built in. There is `rake tmp:cache:clear` but it removes entire content of `tmp/cache` which is less than perfect.