### PR TITLE
HTTP caching for datatables

### DIFF
--- a/app/controllers/data_tables_controller.rb
+++ b/app/controllers/data_tables_controller.rb
@@ -6,7 +6,7 @@ class DataTablesController < ApplicationController
         model_param
       end
       format.json do
-        cache_key = params.reject{ |k,_| %w(_ controller action).include? k }
+        cache_key = params.reject{ |k,_| %w(_ controller action format).include? k }
         cache_key[:latest_change] = model_klass.maximum('updated_at')
         cache_key[:count] = model_klass.count
         logger.info "CACHE KEY: #{cache_key}"

--- a/app/helpers/data_tables_helper.rb
+++ b/app/helpers/data_tables_helper.rb
@@ -3,7 +3,8 @@ module DataTablesHelper
     data_tables_path(
       query: params[:query],
       fetch: params[:fetch],
-      model: model_param
+      model: model_param,
+      format: :json
     )
   end
 
@@ -12,7 +13,12 @@ module DataTablesHelper
       :table,
       class: 'table table-condensed table-browse table-hover data-table',
       id: model_param.dasherize,
-      data: { ajax: datatables_source }
+      data: {
+        ajax: {
+          url: datatables_source,
+          cache: true
+        }
+      }
     ) do
       content_tag(:thead) do
         content_tag(:tr) do

--- a/spec/helpers/data_tables_helper_spec.rb
+++ b/spec/helpers/data_tables_helper_spec.rb
@@ -25,11 +25,11 @@ RSpec.describe DataTablesHelper do
   describe '#datatables_source' do
     it 'passes model, fetch and query params intact' do
       allow(self).to receive(:params).and_return(model: 'model_name')
-      expect(datatables_source).to eq data_tables_path(model: 'model_name')
+      expect(datatables_source).to eq data_tables_path(model: 'model_name', format: 'json')
       allow(self).to receive(:params).and_return(model: 'model_name', query: { a: 'b' })
-      expect(datatables_source).to eq data_tables_path(model: 'model_name', query: { a: 'b' })
+      expect(datatables_source).to eq data_tables_path(model: 'model_name', query: { a: 'b' }, format: 'json')
       allow(self).to receive(:params).and_return(model: 'model_name', fetch: 'n')
-      expect(datatables_source).to eq data_tables_path(model: 'model_name', fetch: 'n')
+      expect(datatables_source).to eq data_tables_path(model: 'model_name', fetch: 'n', format: 'json')
     end
   end
 


### PR DESCRIPTION
A few small changes were required to make this work:
1. By default datatables make js append cache buster to url params. Solution: add `cache: true` to datatables ajax options.
2. Browser tried to send Etag generated for HTML instead of JSON response. Solution: append format indicator to the url.

Etag generation is handled by RoR itself (AFAIK Etag is computed from rendered response), that's why no other changes in code are required.

Finally, caching will NOT work with invalid SSL certificate. I spend a while to discover this...

Fixes #363 