### PR TITLE
Plant line sequence identifier

### DIFF
--- a/app/assets/javascripts/data_grid_specific_columns.js.coffee
+++ b/app/assets/javascripts/data_grid_specific_columns.js.coffee
@@ -99,6 +99,13 @@ window.configs =
         targets: 'plant_varieties_plant_variety_name_column'
         render: (data, type, full, meta) ->
           modelIdUrl('plant_varieties', data, full[full.length - 2])
+      ,
+        targets: 'plant_lines_sequence_identifier_column'
+        render: (data, type, full, meta) ->
+          if data && data.indexOf("SR") == 0
+            '<a href="http://www.ncbi.nlm.nih.gov/sra/' + data + '" target="blank">' + data + '</a>'
+          else
+            data
       ]
 
   'plant-populations':

--- a/app/models/plant_line.rb
+++ b/app/models/plant_line.rb
@@ -52,6 +52,7 @@ class PlantLine < ActiveRecord::Base
       'plant_varieties.plant_variety_name',
       'previous_line_name',
       'genetic_status',
+      'sequence_identifier',
       'data_owned_by',
       'organisation'
     ]

--- a/config/locales/api.en.yml
+++ b/config/locales/api.en.yml
@@ -297,6 +297,10 @@ en:
           create: Q
           desc: Design method used to obtain this population line (i.e. open pollinated, inbred, substitution lines)
         -
+          name: sequence_identifier
+          create: Q
+          desc: Identifier of the line sequence, in an external database, like NCBI SRA. Identifiers starting with SR will be automatically recognized as SRA submissions.
+        -
           name: previous_line_name
           create: Q
           desc: Old name of the Plant Line, if changed

--- a/config/locales/data_tables.en.yml
+++ b/config/locales/data_tables.en.yml
@@ -56,6 +56,7 @@ en:
       data_owned_by: Data owner
       organisation: Organisation
       genetic_status: Genetic status
+      sequence_identifier: Sequence
     plant_parts:
       plant_part: Plant part
     plant_populations:

--- a/db/migrate/20160315155837_add_sequence_identifier_to_plant_lines.rb
+++ b/db/migrate/20160315155837_add_sequence_identifier_to_plant_lines.rb
@@ -1,0 +1,5 @@
+class AddSequenceIdentifierToPlantLines < ActiveRecord::Migration
+  def change
+    add_column :plant_lines, :sequence_identifier, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160311121620) do
+ActiveRecord::Schema.define(version: 20160315155837) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,19 +20,17 @@ ActiveRecord::Schema.define(version: 20160311121620) do
   create_table "api_keys", force: :cascade do |t|
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "token",                     null: false
-    t.integer  "user_id",                   null: false
-    t.boolean  "published",  default: true, null: false
+    t.string   "token",      null: false
+    t.integer  "user_id",    null: false
   end
 
   add_index "api_keys", ["token"], name: "index_api_keys_on_token", using: :btree
 
   create_table "countries", force: :cascade do |t|
-    t.string   "country_code", limit: 3,                null: false
+    t.string   "country_code", limit: 3, null: false
     t.text     "country_name"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.boolean  "published",              default: true, null: false
   end
 
   add_index "countries", ["country_code"], name: "countries_country_code_idx", using: :btree
@@ -172,10 +170,10 @@ ActiveRecord::Schema.define(version: 20160311121620) do
     t.integer  "linkage_group_id"
     t.integer  "population_locus_id"
     t.integer  "map_locus_hits_count", default: 0,    null: false
-    t.integer  "marker_assay_id"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "user_id"
+    t.integer  "marker_assay_id"
     t.boolean  "published",            default: true, null: false
   end
 
@@ -266,7 +264,7 @@ ActiveRecord::Schema.define(version: 20160311121620) do
   add_index "plant_accessions", ["plant_line_id"], name: "plant_accessions_plant_line_id_idx", using: :btree
 
   create_table "plant_lines", force: :cascade do |t|
-    t.text     "plant_line_name",                   null: false
+    t.text     "plant_line_name",                    null: false
     t.text     "common_name"
     t.text     "plant_variety_name"
     t.text     "named_by_whom"
@@ -284,7 +282,8 @@ ActiveRecord::Schema.define(version: 20160311121620) do
     t.integer  "user_id"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.boolean  "published",          default: true, null: false
+    t.boolean  "published",           default: true, null: false
+    t.string   "sequence_identifier"
   end
 
   add_index "plant_lines", ["plant_line_name"], name: "plant_lines_plant_line_name_idx", using: :btree
@@ -614,10 +613,10 @@ ActiveRecord::Schema.define(version: 20160311121620) do
     t.text     "data_provenance"
     t.text     "data_owned_by"
     t.integer  "qtls_count",                     default: 0,    null: false
-    t.integer  "linkage_map_id"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "user_id"
+    t.integer  "linkage_map_id"
     t.boolean  "published",                      default: true, null: false
   end
 
@@ -753,87 +752,86 @@ ActiveRecord::Schema.define(version: 20160311121620) do
   add_index "trait_scores", ["trait_descriptor_id"], name: "trait_scores_trait_descriptor_id_idx", using: :btree
 
   create_table "users", force: :cascade do |t|
-    t.string   "login",                             null: false
+    t.string   "login",                          null: false
     t.string   "email"
     t.string   "full_name"
-    t.datetime "created_at",                        null: false
-    t.datetime "updated_at",                        null: false
-    t.integer  "sign_in_count",      default: 0,    null: false
+    t.datetime "created_at",                     null: false
+    t.datetime "updated_at",                     null: false
+    t.integer  "sign_in_count",      default: 0, null: false
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
     t.string   "current_sign_in_ip"
     t.string   "last_sign_in_ip"
-    t.boolean  "published",          default: true, null: false
   end
 
   add_index "users", ["login"], name: "index_users_on_login", unique: true, using: :btree
 
   add_foreign_key "api_keys", "users", on_update: :cascade, on_delete: :cascade
-  add_foreign_key "genotype_matrices", "linkage_maps", on_delete: :nullify
-  add_foreign_key "linkage_groups", "linkage_maps", on_delete: :nullify
+  add_foreign_key "genotype_matrices", "linkage_maps", on_update: :cascade, on_delete: :nullify
+  add_foreign_key "linkage_groups", "linkage_maps", on_update: :cascade, on_delete: :nullify
   add_foreign_key "linkage_groups", "users", on_update: :cascade, on_delete: :nullify
-  add_foreign_key "linkage_maps", "plant_populations", on_delete: :nullify
+  add_foreign_key "linkage_maps", "plant_populations", on_update: :cascade, on_delete: :nullify
   add_foreign_key "linkage_maps", "users", on_update: :cascade, on_delete: :nullify
-  add_foreign_key "map_locus_hits", "linkage_groups", on_delete: :nullify
-  add_foreign_key "map_locus_hits", "linkage_maps", on_delete: :nullify
-  add_foreign_key "map_locus_hits", "map_positions", on_delete: :nullify
-  add_foreign_key "map_locus_hits", "population_loci", on_delete: :nullify
+  add_foreign_key "map_locus_hits", "linkage_groups", on_update: :cascade, on_delete: :nullify
+  add_foreign_key "map_locus_hits", "linkage_maps", on_update: :cascade, on_delete: :nullify
+  add_foreign_key "map_locus_hits", "map_positions", on_update: :cascade, on_delete: :nullify
+  add_foreign_key "map_locus_hits", "population_loci", on_update: :cascade, on_delete: :nullify
   add_foreign_key "map_locus_hits", "users", on_update: :cascade, on_delete: :nullify
-  add_foreign_key "map_positions", "linkage_groups", on_delete: :nullify
+  add_foreign_key "map_positions", "linkage_groups", on_update: :cascade, on_delete: :nullify
   add_foreign_key "map_positions", "marker_assays", on_update: :cascade, on_delete: :nullify
-  add_foreign_key "map_positions", "population_loci", on_delete: :nullify
+  add_foreign_key "map_positions", "population_loci", on_update: :cascade, on_delete: :nullify
   add_foreign_key "map_positions", "users", on_update: :cascade, on_delete: :nullify
-  add_foreign_key "marker_assays", "marker_sequence_assignments", on_delete: :nullify
-  add_foreign_key "marker_assays", "primers", column: "primer_a_id", on_delete: :nullify
-  add_foreign_key "marker_assays", "primers", column: "primer_b_id", on_delete: :nullify
-  add_foreign_key "marker_assays", "probes", on_delete: :nullify
-  add_foreign_key "marker_assays", "restriction_enzymes", column: "restriction_enzyme_a_id", on_delete: :nullify
-  add_foreign_key "marker_assays", "restriction_enzymes", column: "restriction_enzyme_b_id", on_delete: :nullify
+  add_foreign_key "marker_assays", "marker_sequence_assignments", on_update: :cascade, on_delete: :nullify
+  add_foreign_key "marker_assays", "primers", column: "primer_a_id", on_update: :cascade, on_delete: :nullify
+  add_foreign_key "marker_assays", "primers", column: "primer_b_id", on_update: :cascade, on_delete: :nullify
+  add_foreign_key "marker_assays", "probes", on_update: :cascade, on_delete: :nullify
+  add_foreign_key "marker_assays", "restriction_enzymes", column: "restriction_enzyme_a_id", on_update: :cascade, on_delete: :nullify
+  add_foreign_key "marker_assays", "restriction_enzymes", column: "restriction_enzyme_b_id", on_update: :cascade, on_delete: :nullify
   add_foreign_key "marker_assays", "users", on_update: :cascade, on_delete: :nullify
-  add_foreign_key "plant_accessions", "plant_lines", on_delete: :nullify
+  add_foreign_key "plant_accessions", "plant_lines", on_update: :cascade, on_delete: :nullify
   add_foreign_key "plant_accessions", "users", on_update: :cascade, on_delete: :nullify
-  add_foreign_key "plant_lines", "plant_varieties", on_delete: :nullify
-  add_foreign_key "plant_lines", "taxonomy_terms", on_delete: :nullify
+  add_foreign_key "plant_lines", "plant_varieties", on_update: :cascade, on_delete: :nullify
+  add_foreign_key "plant_lines", "taxonomy_terms", on_update: :cascade, on_delete: :nullify
   add_foreign_key "plant_lines", "users", on_update: :cascade, on_delete: :nullify
-  add_foreign_key "plant_population_lists", "plant_lines", on_delete: :nullify
-  add_foreign_key "plant_population_lists", "plant_populations", on_delete: :nullify
+  add_foreign_key "plant_population_lists", "plant_lines", on_update: :cascade, on_delete: :nullify
+  add_foreign_key "plant_population_lists", "plant_populations", on_update: :cascade, on_delete: :nullify
   add_foreign_key "plant_population_lists", "users", on_update: :cascade, on_delete: :nullify
-  add_foreign_key "plant_populations", "plant_lines", column: "female_parent_line_id", on_delete: :nullify
-  add_foreign_key "plant_populations", "plant_lines", column: "male_parent_line_id", on_delete: :nullify
-  add_foreign_key "plant_populations", "pop_type_lookup", column: "population_type_id", on_delete: :nullify
-  add_foreign_key "plant_populations", "taxonomy_terms", on_delete: :nullify
+  add_foreign_key "plant_populations", "plant_lines", column: "female_parent_line_id", on_update: :cascade, on_delete: :nullify
+  add_foreign_key "plant_populations", "plant_lines", column: "male_parent_line_id", on_update: :cascade, on_delete: :nullify
+  add_foreign_key "plant_populations", "pop_type_lookup", column: "population_type_id", on_update: :cascade, on_delete: :nullify
+  add_foreign_key "plant_populations", "taxonomy_terms", on_update: :cascade, on_delete: :nullify
   add_foreign_key "plant_populations", "users", on_update: :cascade, on_delete: :nullify
-  add_foreign_key "plant_scoring_units", "design_factors", on_delete: :nullify
-  add_foreign_key "plant_scoring_units", "plant_accessions", on_delete: :nullify
-  add_foreign_key "plant_scoring_units", "plant_parts", on_delete: :nullify
-  add_foreign_key "plant_scoring_units", "plant_trials", on_delete: :nullify
+  add_foreign_key "plant_scoring_units", "design_factors", on_update: :cascade, on_delete: :nullify
+  add_foreign_key "plant_scoring_units", "plant_accessions", on_update: :cascade, on_delete: :nullify
+  add_foreign_key "plant_scoring_units", "plant_parts", on_update: :cascade, on_delete: :nullify
+  add_foreign_key "plant_scoring_units", "plant_trials", on_update: :cascade, on_delete: :nullify
   add_foreign_key "plant_scoring_units", "users", on_update: :cascade, on_delete: :nullify
-  add_foreign_key "plant_trials", "countries", on_delete: :nullify
-  add_foreign_key "plant_trials", "plant_populations", on_delete: :nullify
+  add_foreign_key "plant_trials", "countries", on_update: :cascade, on_delete: :nullify
+  add_foreign_key "plant_trials", "plant_populations", on_update: :cascade, on_delete: :nullify
   add_foreign_key "plant_trials", "users", on_update: :cascade, on_delete: :nullify
   add_foreign_key "plant_varieties", "users", on_update: :cascade, on_delete: :nullify
-  add_foreign_key "plant_variety_country_of_origin", "countries", on_delete: :nullify
-  add_foreign_key "plant_variety_country_of_origin", "plant_varieties", on_delete: :nullify
-  add_foreign_key "plant_variety_country_registered", "countries", on_delete: :nullify
-  add_foreign_key "plant_variety_country_registered", "plant_varieties", on_delete: :nullify
-  add_foreign_key "population_loci", "marker_assays", on_delete: :nullify
-  add_foreign_key "population_loci", "plant_populations", on_delete: :nullify
+  add_foreign_key "plant_variety_country_of_origin", "countries", on_update: :cascade, on_delete: :nullify
+  add_foreign_key "plant_variety_country_of_origin", "plant_varieties", on_update: :cascade, on_delete: :nullify
+  add_foreign_key "plant_variety_country_registered", "countries", on_update: :cascade, on_delete: :nullify
+  add_foreign_key "plant_variety_country_registered", "plant_varieties", on_update: :cascade, on_delete: :nullify
+  add_foreign_key "population_loci", "marker_assays", on_update: :cascade, on_delete: :nullify
+  add_foreign_key "population_loci", "plant_populations", on_update: :cascade, on_delete: :nullify
   add_foreign_key "population_loci", "users", on_update: :cascade, on_delete: :nullify
   add_foreign_key "primers", "users", on_update: :cascade, on_delete: :nullify
-  add_foreign_key "probes", "taxonomy_terms", on_delete: :nullify
+  add_foreign_key "probes", "taxonomy_terms", on_update: :cascade, on_delete: :nullify
   add_foreign_key "probes", "users", on_update: :cascade, on_delete: :nullify
-  add_foreign_key "processed_trait_datasets", "plant_trials", on_delete: :nullify
-  add_foreign_key "processed_trait_datasets", "trait_descriptors", on_delete: :nullify
-  add_foreign_key "qtl", "linkage_groups", on_delete: :nullify
-  add_foreign_key "qtl", "processed_trait_datasets", on_delete: :nullify
-  add_foreign_key "qtl", "qtl_jobs", on_delete: :nullify
+  add_foreign_key "processed_trait_datasets", "plant_trials", on_update: :cascade, on_delete: :nullify
+  add_foreign_key "processed_trait_datasets", "trait_descriptors", on_update: :cascade, on_delete: :nullify
+  add_foreign_key "qtl", "linkage_groups", on_update: :cascade, on_delete: :nullify
+  add_foreign_key "qtl", "processed_trait_datasets", on_update: :cascade, on_delete: :nullify
+  add_foreign_key "qtl", "qtl_jobs", on_update: :cascade, on_delete: :nullify
   add_foreign_key "qtl", "users", on_update: :cascade, on_delete: :nullify
   add_foreign_key "qtl_jobs", "linkage_maps", on_update: :cascade, on_delete: :nullify
   add_foreign_key "qtl_jobs", "users", on_update: :cascade, on_delete: :nullify
   add_foreign_key "submission_uploads", "submissions", on_update: :cascade, on_delete: :restrict
   add_foreign_key "trait_descriptors", "users", on_update: :cascade, on_delete: :nullify
-  add_foreign_key "trait_grades", "trait_descriptors", on_delete: :nullify
-  add_foreign_key "trait_scores", "plant_scoring_units", on_delete: :nullify
-  add_foreign_key "trait_scores", "trait_descriptors", on_delete: :nullify
+  add_foreign_key "trait_grades", "trait_descriptors", on_update: :cascade, on_delete: :nullify
+  add_foreign_key "trait_scores", "plant_scoring_units", on_update: :cascade, on_delete: :nullify
+  add_foreign_key "trait_scores", "trait_descriptors", on_update: :cascade, on_delete: :nullify
   add_foreign_key "trait_scores", "users", on_update: :cascade, on_delete: :nullify
 end

--- a/spec/models/concerns/searchable_spec.rb
+++ b/spec/models/concerns/searchable_spec.rb
@@ -40,6 +40,7 @@ RSpec.describe Searchable do
           :common_name,
           :previous_line_name,
           :genetic_status,
+          :sequence_identifier,
           :data_owned_by,
           :organisation
         ],

--- a/spec/models/plant_line_spec.rb
+++ b/spec/models/plant_line_spec.rb
@@ -113,6 +113,7 @@ RSpec.describe PlantLine do
         pl.plant_variety.plant_variety_name,
         pl.previous_line_name,
         pl.genetic_status,
+        pl.sequence_identifier,
         pl.data_owned_by,
         pl.organisation,
         pl.plant_variety.id,

--- a/spec/services/api/create_params_spec.rb
+++ b/spec/services/api/create_params_spec.rb
@@ -5,9 +5,9 @@ RSpec.describe Api::CreateParams do
     it "allows scalar model attributes" do
       pl_permissions = Api::CreateParams.new(Api::Model.new('plant_line'), {}).permissions
       expect(pl_permissions).to match_array %w(plant_line_name common_name
-        organisation genetic_status previous_line_name comments named_by_whom
-        data_provenance data_owned_by confirmed_by_whom taxonomy_term_id
-        plant_variety_id plant_variety_name published)
+        organisation sequence_identifier genetic_status previous_line_name
+        comments named_by_whom data_provenance data_owned_by confirmed_by_whom
+        taxonomy_term_id plant_variety_id plant_variety_name published)
     end
 
     it "allows arrays of ids for HABTM associations" do


### PR DESCRIPTION
Fixes issues #400 and #401. Makes #427 possible.

Currently we only "recognize" SRA identifiers (i.e. we make them into hyperlinks in the data tables). The Ensembl links were, eventually, not discussed with Wiktor.