### PR TITLE
453 published switch for submissions

### DIFF
--- a/app/assets/stylesheets/partials/_base.scss
+++ b/app/assets/stylesheets/partials/_base.scss
@@ -55,4 +55,10 @@ hr {
   background-color: $rss-color;
 }
 
-
+/* other */
+.actions {
+  transition: none;
+  form {
+    display: inline-block;
+  }
+}

--- a/app/assets/stylesheets/partials/_submissions.scss
+++ b/app/assets/stylesheets/partials/_submissions.scss
@@ -5,22 +5,21 @@
     @extend .list-group-item;
     .main-info {
       display: inline-block;
-      width: 70%;
+      width: 60%;
     }
     .details {
+      font-size: small;
       margin-right: 20px;
+      margin-top: 4px;
     }
-    .updated-at {
+    .status {
       display: inline-block;
-      width: 15%;
-    }
-    .finalized-at {
-      display: inline-block;
-      width: 15%;
+      width: 22%;
     }
     .actions {
       float: right;
-      width: 14%;
+      width: 17%;
+      margin-top: 6px;
       text-align: right;
       transition: none;
       form {

--- a/app/assets/stylesheets/partials/_submissions.scss
+++ b/app/assets/stylesheets/partials/_submissions.scss
@@ -21,11 +21,17 @@
       width: 17%;
       margin-top: 6px;
       text-align: right;
-      transition: none;
-      form {
-        display: inline-block;
-      }
     }
+  }
+}
+
+.show-submission {
+  .status {
+    margin-bottom: 2px;
+  }
+  .details {
+    margin-top: 2px;
+    font-size: small;
   }
 }
 
@@ -105,4 +111,3 @@
     }
   }
 }
-

--- a/app/controllers/api/v1/resources_controller.rb
+++ b/app/controllers/api/v1/resources_controller.rb
@@ -60,7 +60,7 @@ class Api::V1::ResourcesController < Api::BaseController
       render json: { reason: 'Resource not found' }, status: :not_found
     elsif resource.user != @api_key.user
       render json: { reason: 'API key owner and resource owner mismatch' }, status: :unauthorized
-    elsif !resource.revocable?
+    elsif resource.published? && !resource.revocable?
       render json: { reason: 'This resource is already published and irrevocable' }, status: :forbidden
     else
       resource.destroy

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -67,10 +67,14 @@ class SubmissionsController < ApplicationController
   end
 
   def publish
+    submission = current_user.submissions.find(params[:id])
+    publisher(submission).publish
     redirect_to submissions_path, notice: "Submission published"
   end
 
   def revoke
+    submission = current_user.submissions.find(params[:id])
+    publisher(submission).revoke
     redirect_to submissions_path, notice: "Publication revoked"
   end
 
@@ -104,6 +108,16 @@ class SubmissionsController < ApplicationController
       PlantTrialSubmissionDecorator.decorate(submission)
     else
       nil
+    end
+  end
+
+  def publisher(submission)
+    case submission.submission_type
+    when 'population'
+      Submission::PlantPopulationPublisher.new(submission)
+    when 'trial'
+      Submission::PlantTrialPublisher.new(submission)
+    else
     end
   end
 end

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -66,6 +66,14 @@ class SubmissionsController < ApplicationController
     redirect_to submissions_path, notice: "Submission deleted"
   end
 
+  def publish
+    redirect_to submissions_path, notice: "Submission published"
+  end
+
+  def revoke
+    redirect_to submissions_path, notice: "Publication revoked"
+  end
+
   private
 
   def step_content_form(submission, step_content_params = nil)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -64,4 +64,14 @@ module ApplicationHelper
       title: title, props: props
     }
   end
+
+  def confirmable_action(label, object, options = {}, &blk)
+    options = options.dup
+    options[:method] ||= :post
+    options[:url] ||= url_for(object)
+    options[:btn_class] ||= "btn-default"
+    options[:other_content] ||= capture(&blk) if block_given?
+
+    render partial: "/confirmable_action", locals: options.merge(label: label, object: object)
+  end
 end

--- a/app/helpers/submissions_helper.rb
+++ b/app/helpers/submissions_helper.rb
@@ -4,7 +4,7 @@ module SubmissionsHelper
   end
 
   def my_submissions_button
-    link_to "My submissions", submissions_path, class: 'btn btn-primary'
+    link_to "My submissions", submissions_path, class: 'btn btn-default btn-sm'
   end
 
   def submission_private_link(submission)

--- a/app/models/concerns/publishable.rb
+++ b/app/models/concerns/publishable.rb
@@ -15,7 +15,11 @@ module Publishable
     }
 
     def revocable?
-      !published? || (published_on > Time.now - 1.week)
+      !published? || Time.now < revocable_until
+    end
+
+    def revocable_until
+      published_on + 1.week if published?
     end
   end
 end

--- a/app/models/concerns/publishable.rb
+++ b/app/models/concerns/publishable.rb
@@ -6,6 +6,8 @@ module Publishable
 
     validates_with PublicationValidator
 
+    scope :published, -> { where(published: true) }
+    scope :not_published, -> { where(published: false) }
     scope :visible, ->(uid = nil) {
       if uid.present?
         where("published = 't' OR user_id = #{uid}")
@@ -15,7 +17,7 @@ module Publishable
     }
 
     def revocable?
-      !published? || Time.now < revocable_until
+      published? && Time.now < revocable_until
     end
 
     def revocable_until

--- a/app/models/plant_population.rb
+++ b/app/models/plant_population.rb
@@ -7,22 +7,15 @@ class PlantPopulation < ActiveRecord::Base
              foreign_key: 'female_parent_line_id'
   belongs_to :user
 
-  has_many :linkage_maps,
-           dependent: :nullify
-  has_many :population_loci,
-           dependent: :nullify
-  has_many :plant_trials,
-           dependent: :nullify
+  has_many :linkage_maps, dependent: :nullify
+  has_many :population_loci, dependent: :nullify
+  has_many :plant_trials, dependent: :nullify
 
   has_many :plant_population_lists, dependent: :delete_all
-  has_many :plant_lines,
-           through: :plant_population_lists
+  has_many :plant_lines, through: :plant_population_lists
 
-  validates :name,
-            presence: true,
-            uniqueness: true
-  validates :user,
-            presence: { on: :create }
+  validates :name, presence: true, uniqueness: true
+  validates :user, presence: { on: :create }
 
   after_update { population_loci.each(&:touch) }
   after_update { linkage_maps.each(&:touch) }

--- a/app/models/plant_population_list.rb
+++ b/app/models/plant_population_list.rb
@@ -7,8 +7,7 @@ class PlantPopulationList < ActiveRecord::Base
             presence: true,
             uniqueness: { scope: :plant_population }
 
-  validates :plant_population_id,
-            presence: true
+  validates :plant_population_id, presence: true
 
   include Publishable
   include Annotable

--- a/app/models/plant_scoring_unit.rb
+++ b/app/models/plant_scoring_unit.rb
@@ -7,8 +7,7 @@ class PlantScoringUnit < ActiveRecord::Base
 
   has_many :trait_scores, dependent: :destroy
 
-  validates :scoring_unit_name,
-            presence: true
+  validates :scoring_unit_name, presence: true
 
   include Relatable
   include Filterable

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -70,6 +70,18 @@ class Submission < ActiveRecord::Base
     finalized? ? associated_model.find(submitted_object_id) : nil
   end
 
+  def revocable?
+    submitted_object && submitted_object.revocable?
+  end
+
+  def revocable_until
+    submitted_object.try(:revocable_until)
+  end
+
+  def published_on
+    submitted_object.try(:published_on)
+  end
+
   def steps
     STEPS
   end

--- a/app/models/trait_score.rb
+++ b/app/models/trait_score.rb
@@ -3,8 +3,7 @@ class TraitScore < ActiveRecord::Base
   belongs_to :trait_descriptor, counter_cache: true
   belongs_to :user
 
-  validates :score_value,
-            presence: true
+  validates :score_value, presence: true
 
   include Filterable
   include Pluckable

--- a/app/services/submission/plant_population_publisher.rb
+++ b/app/services/submission/plant_population_publisher.rb
@@ -1,0 +1,21 @@
+class Submission::PlantPopulationPublisher < Submission::Publisher
+
+  private
+
+  def associated_collections
+    [plant_lines, plant_population_lists]
+  end
+
+  def plant_population
+    raise ArgumentError, "Wrong submission type" unless submission.population?
+    submission.submitted_object
+  end
+
+  def plant_lines
+    plant_population.plant_lines.where(user_id: submission.user)
+  end
+
+  def plant_population_lists
+    plant_population.plant_population_lists.where(user_id: submission.user)
+  end
+end

--- a/app/services/submission/plant_trial_publisher.rb
+++ b/app/services/submission/plant_trial_publisher.rb
@@ -1,0 +1,26 @@
+class Submission::PlantTrialPublisher < Submission::Publisher
+
+  private
+
+  def associated_collections
+    [plant_scoring_units, trait_scores, trait_descriptors]
+  end
+
+  def plant_trial
+    raise ArgumentError, "Wrong submission type" unless submission.trial?
+    submission.submitted_object
+  end
+
+  def plant_scoring_units
+    plant_trial.plant_scoring_units.where(user_id: submission.user)
+  end
+
+  def trait_scores
+    TraitScore.where(user_id: submission.user).of_trial(plant_trial)
+  end
+
+  def trait_descriptors
+    TraitDescriptor.where(user_id: submission.user,
+                          id: trait_scores.pluck("DISTINCT trait_descriptor_id"))
+  end
+end

--- a/app/services/submission/plant_trial_publisher.rb
+++ b/app/services/submission/plant_trial_publisher.rb
@@ -16,7 +16,7 @@ class Submission::PlantTrialPublisher < Submission::Publisher
   end
 
   def trait_scores
-    TraitScore.where(user_id: submission.user).of_trial(plant_trial)
+    TraitScore.where(user_id: submission.user).of_trial(plant_trial.id)
   end
 
   def trait_descriptors

--- a/app/services/submission/publisher.rb
+++ b/app/services/submission/publisher.rb
@@ -9,6 +9,7 @@ class Submission::Publisher
 
   def publish
     raise ArgumentError, "Submission is published" if submission.publishable?
+
     now = Time.zone.now
     submission.transaction do
       submission.update_attributes!(publishable: true)
@@ -21,6 +22,8 @@ class Submission::Publisher
 
   def revoke
     raise ArgumentError, "Submission is not published" unless submission.publishable?
+    raise ArgumentError, "Submission is not revocable" unless submission.revocable?
+
     submission.transaction do
       submission.update_attributes!(publishable: false)
       revoke_object(submission.submitted_object)

--- a/app/services/submission/publisher.rb
+++ b/app/services/submission/publisher.rb
@@ -1,0 +1,46 @@
+class Submission::Publisher
+  attr_accessor :submission
+
+  def initialize(submission)
+    raise ArgumentError, "Submission not finalized" unless submission.finalized?
+
+    self.submission = submission
+  end
+
+  def publish
+    raise ArgumentError, "Submission is published" if submission.publishable?
+    now = Time.zone.now
+    submission.transaction do
+      submission.update_attributes!(publishable: true)
+      publish_object(submission.submitted_object, now)
+      associated_collections.each do |collection|
+        collection.not_published.each { |instance| publish_object(instance, now) }
+      end
+    end
+  end
+
+  def revoke
+    raise ArgumentError, "Submission is not published" unless submission.publishable?
+    submission.transaction do
+      submission.update_attributes!(publishable: false)
+      revoke_object(submission.submitted_object)
+      associated_collections.each do |collection|
+        collection.each { |instance| revoke_object(instance) }
+      end
+    end
+  end
+
+  private
+
+  def publish_object(object, time)
+    object.update_attributes!(published: true, published_on: time)
+  end
+
+  def revoke_object(object)
+    object.update_attributes!(published: false, published_on: nil)
+  end
+
+  def associated_collections
+    raise NotImplemented, "Must be implemented by subclasses"
+  end
+end

--- a/app/validators/publication_validator.rb
+++ b/app/validators/publication_validator.rb
@@ -6,7 +6,7 @@ class PublicationValidator < ActiveModel::Validator
       end
     end
 
-    if !(record.published) and record.user_id.blank?
+    if !record.published && record.user_id.blank?
       record.errors[:published] << 'An ownerless record must have its published flag set to true.'
     end
   end

--- a/app/views/_confirmable_action.html.haml
+++ b/app/views/_confirmable_action.html.haml
@@ -1,0 +1,10 @@
+.actions.collapse{data: { confirmation: object.id }}
+  Sure?
+  = button_to 'Yes', url, method: method, class: 'btn btn-sm btn-warning'
+  %a.btn.btn-sm.btn-default{href: "[data-confirmation=#{object.id}]", data: { toggle: 'collapse' }}
+    No
+
+.actions.collapse.in{data: { confirmation: object.id }}
+  = other_content.html_safe if defined?(other_content)
+  %a.btn.btn-sm{class: btn_class, href: "[data-confirmation=#{object.id}]", data: { toggle: 'collapse' }}
+    = label

--- a/app/views/submissions/_submissions_list.html.haml
+++ b/app/views/submissions/_submissions_list.html.haml
@@ -14,44 +14,14 @@
           = submission_details(submission)
 
       - unless submission.finalized?
-        .status
-          %span.label.label-default Draft
-          .details
-            Modified on #{l submission.updated_at, format: :short}
+        = render partial: "/submissions/show/status", locals: { submission: submission }
 
         - unless mode == :public
-          .actions.collapse{data: { confirmation: submission.id }}
-            Sure?
-            = button_to 'Yes', submission_path(submission), method: :delete, class: 'btn btn-sm btn-warning'
-            %a.btn.btn-sm.btn-default{href: "[data-confirmation=#{submission.id}]", data: { toggle: 'collapse' }}
-              No
-
-          .actions.collapse.in{data: { confirmation: submission.id }}
+          = confirmable_action("Delete", submission, method: :delete, btn_class: "btn-warning") do
             = link_to 'Edit', edit_submission_path(submission), class: 'btn btn-sm btn-default'
-            %a.btn.btn-sm.btn-warning{href: "[data-confirmation=#{submission.id}]", data: { toggle: 'collapse' }}
-              Delete
 
       - else
-        .status
-          - if submission.publishable?
-            %span.label.label-primary Submitted &#183; Published
-          - else
-            %span.label.label-info Submitted &#183; Private
-
-          .details
-            - if submission.revocable?
-              Revocable until #{l submission.revocable_until.utc, format: :short} UTC
-
-              - tooltip = capture do
-                .text-left
-                  Published data can be revoked for 7 days from the publication.<br>
-                  This submission was published on #{l submission.published_on.utc, format: :short} UTC
-
-              %span{data: {toggle: :tooltip, html: 'true'}, title: tooltip}
-                %i.fa.fa-info-circle
-
-            - else
-              Submitted on #{l submission.updated_at, format: :short}
+        = render partial: "/submissions/show/status", locals: { submission: submission }
 
         - if mode == :public
           .actions
@@ -61,24 +31,9 @@
 
         - else
           - if submission.publishable? && submission.revocable?
-            .actions.collapse{data: { confirmation: submission.id }}
-              Sure?
-              = button_to 'Yes', revoke_submission_path(submission), method: :patch, class: 'btn btn-sm btn-warning'
-              %a.btn.btn-sm.btn-default{href: "[data-confirmation=#{submission.id}]", data: { toggle: 'collapse' }}
-                No
-
-            .actions.collapse.in{data: { confirmation: submission.id }}
-              %a.btn.btn-sm.btn-default{href: "[data-confirmation=#{submission.id}]", data: { toggle: 'collapse' }}
-                Revoke publication
+            = confirmable_action("Revoke publication", submission,
+                url: revoke_submission_path(submission), method: :patch)
 
           - else
-            .actions.collapse{data: { confirmation: submission.id }}
-              Sure?
-              = button_to 'Yes', publish_submission_path(submission), method: :patch, class: 'btn btn-sm btn-warning'
-              %a.btn.btn-sm.btn-default{href: "[data-confirmation=#{submission.id}]", data: { toggle: 'collapse' }}
-                No
-
-            .actions.collapse.in{data: { confirmation: submission.id }}
-              %a.btn.btn-sm.btn-primary{href: "[data-confirmation=#{submission.id}]", data: { toggle: 'collapse' }}
-                Publish
-
+            = confirmable_action("Publish", submission,
+                url: publish_submission_path(submission), method: :patch, btn_class: "btn-primary")

--- a/app/views/submissions/_submissions_list.html.haml
+++ b/app/views/submissions/_submissions_list.html.haml
@@ -14,33 +14,71 @@
           = submission_details(submission)
 
       - unless submission.finalized?
-        .updated-at
-          .text Last modification
+        .status
+          %span.label.label-default Draft
           .details
-            = l submission.updated_at, format: :long
+            Modified on #{l submission.updated_at, format: :short}
+
         - unless mode == :public
           .actions.collapse{data: { confirmation: submission.id }}
             Sure?
-            = button_to 'Yes', submission_path(submission), method: :delete, class: 'btn btn-warning'
-            %a.btn.btn-default{href: "[data-confirmation=#{submission.id}]", data: { toggle: 'collapse' }}
+            = button_to 'Yes', submission_path(submission), method: :delete, class: 'btn btn-sm btn-warning'
+            %a.btn.btn-sm.btn-default{href: "[data-confirmation=#{submission.id}]", data: { toggle: 'collapse' }}
               No
+
           .actions.collapse.in{data: { confirmation: submission.id }}
-            = link_to 'Edit', edit_submission_path(submission), class: 'btn btn-default'
-            %a.btn.btn-warning{href: "[data-confirmation=#{submission.id}]", data: { toggle: 'collapse' }}
+            = link_to 'Edit', edit_submission_path(submission), class: 'btn btn-sm btn-default'
+            %a.btn.btn-sm.btn-warning{href: "[data-confirmation=#{submission.id}]", data: { toggle: 'collapse' }}
               Delete
 
       - else
-        .finalized-at
-          .text Submitted on
-          .details
-            = l submission.updated_at, format: :long
+        .status
+          - if submission.publishable?
+            %span.label.label-primary Submitted &#183; Published
+          - else
+            %span.label.label-info Submitted &#183; Private
 
-        .actions
-          - if mode == :public
+          .details
+            - if submission.revocable?
+              Revocable until #{l submission.revocable_until.utc, format: :short} UTC
+
+              - tooltip = capture do
+                .text-left
+                  Published data can be revoked for 7 days from the publication.<br>
+                  This submission was published on #{l submission.published_on.utc, format: :short} UTC
+
+              %span{data: {toggle: :tooltip, html: 'true'}, title: tooltip}
+                %i.fa.fa-info-circle
+
+            - else
+              Submitted on #{l submission.updated_at, format: :short}
+
+        - if mode == :public
+          .actions
             = link_to 'Details',
               submission_details_path(submission),
-              class: 'btn btn-default'
+              class: 'btn btn-sm btn-default'
+
+        - else
+          - if submission.publishable? && submission.revocable?
+            .actions.collapse{data: { confirmation: submission.id }}
+              Sure?
+              = button_to 'Yes', revoke_submission_path(submission), method: :patch, class: 'btn btn-sm btn-warning'
+              %a.btn.btn-sm.btn-default{href: "[data-confirmation=#{submission.id}]", data: { toggle: 'collapse' }}
+                No
+
+            .actions.collapse.in{data: { confirmation: submission.id }}
+              %a.btn.btn-sm.btn-default{href: "[data-confirmation=#{submission.id}]", data: { toggle: 'collapse' }}
+                Revoke publication
+
           - else
-            .text-success
-              %i.fa.fa-check-circle
-              Submission finished
+            .actions.collapse{data: { confirmation: submission.id }}
+              Sure?
+              = button_to 'Yes', publish_submission_path(submission), method: :patch, class: 'btn btn-sm btn-warning'
+              %a.btn.btn-sm.btn-default{href: "[data-confirmation=#{submission.id}]", data: { toggle: 'collapse' }}
+                No
+
+            .actions.collapse.in{data: { confirmation: submission.id }}
+              %a.btn.btn-sm.btn-primary{href: "[data-confirmation=#{submission.id}]", data: { toggle: 'collapse' }}
+                Publish
+

--- a/app/views/submissions/_submissions_list.html.haml
+++ b/app/views/submissions/_submissions_list.html.haml
@@ -14,14 +14,14 @@
           = submission_details(submission)
 
       - unless submission.finalized?
-        = render partial: "/submissions/show/status", locals: { submission: submission }
+        = render partial: "/submissions/show/status", locals: { submission: submission, mode: mode }
 
         - unless mode == :public
           = confirmable_action("Delete", submission, method: :delete, btn_class: "btn-warning") do
             = link_to 'Edit', edit_submission_path(submission), class: 'btn btn-sm btn-default'
 
       - else
-        = render partial: "/submissions/show/status", locals: { submission: submission }
+        = render partial: "/submissions/show/status", locals: { submission: submission, mode: mode }
 
         - if mode == :public
           .actions

--- a/app/views/submissions/show.html.haml
+++ b/app/views/submissions/show.html.haml
@@ -6,7 +6,7 @@
       %h4= @submission.name
 
     .col-sm-4.text-right
-      = render partial: "/submissions/show/status", locals: { submission: @submission }
+      = render partial: "/submissions/show/status", locals: { submission: @submission, mode: :private }
 
   .panel.panel-default
 

--- a/app/views/submissions/show.html.haml
+++ b/app/views/submissions/show.html.haml
@@ -1,10 +1,28 @@
-.container
+.container.show-submission
   %h3.section-heading Submission of #{@submission.submission_type}
-  %h4= @submission.name
+
+  .row
+    .col-sm-8
+      %h4= @submission.name
+
+    .col-sm-4.text-right
+      = render partial: "/submissions/show/status", locals: { submission: @submission }
 
   .panel.panel-default
 
     %ul.list-group
       = render "submissions/show/#{@submission.object.submission_type}"
 
-  = my_submissions_button
+  .row
+    .col-sm-6
+      = my_submissions_button
+
+    .col-sm-6.text-right
+      - if @submission.finalized?
+        - if @submission.publishable? && @submission.revocable?
+          = confirmable_action("Revoke publication", @submission,
+              url: revoke_submission_path(@submission), method: :patch)
+        - else
+          = confirmable_action("Publish", @submission,
+              url: publish_submission_path(@submission), method: :patch, btn_class: "btn-primary")
+

--- a/app/views/submissions/show/_status.html.haml
+++ b/app/views/submissions/show/_status.html.haml
@@ -1,12 +1,15 @@
+- mode = :public unless defined?(mode)
+
 .status
   - if submission.finalized?
-    - if submission.publishable?
-      %span.label.label-primary Submitted &#183; Published
-    - else
-      %span.label.label-info Submitted &#183; Private
+    - if mode == :private
+      - if submission.publishable?
+        %span.label.label-primary Submitted &#183; Published
+      - else
+        %span.label.label-info Submitted &#183; Private
 
     .details
-      - if submission.revocable?
+      - if mode == :private && submission.revocable?
         Revocable until #{l submission.revocable_until.utc, format: :short} UTC
 
         - tooltip = capture do

--- a/app/views/submissions/show/_status.html.haml
+++ b/app/views/submissions/show/_status.html.haml
@@ -1,0 +1,26 @@
+.status
+  - if submission.finalized?
+    - if submission.publishable?
+      %span.label.label-primary Submitted &#183; Published
+    - else
+      %span.label.label-info Submitted &#183; Private
+
+    .details
+      - if submission.revocable?
+        Revocable until #{l submission.revocable_until.utc, format: :short} UTC
+
+        - tooltip = capture do
+          .text-left
+            Published data can be revoked for 7 days from the publication.<br>
+            This submission was published on #{l submission.published_on.utc, format: :short} UTC
+
+        %span{data: {toggle: :tooltip, html: 'true'}, title: tooltip}
+          %i.fa.fa-info-circle
+
+      - else
+        Submitted on #{l submission.updated_at, format: :short}
+
+  - else
+    %span.label.label-default Draft
+    .details
+      Modified on #{l submission.updated_at, format: :short}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,10 @@ Rails.application.routes.draw do
   get 'api_documentation', to: 'application#api'
 
   resources :submissions do
+    member do
+      patch :publish
+      patch :revoke
+    end
     resources :uploads, controller: 'submissions/uploads', only: [:new, :create, :destroy]
   end
   resources :plant_lines, only: [:index]

--- a/spec/factories/plant_line.rb
+++ b/spec/factories/plant_line.rb
@@ -12,14 +12,20 @@ FactoryGirl.define do
     annotable
 
     trait :with_has_many_associations do
-      after(:create) do |plant_line_registry, evaluator|
-        plant_line_registry.fathered_descendants = build_list(:plant_population, 2, male_parent_line_id: evaluator.id)
-        plant_line_registry.mothered_descendants = build_list(:plant_population, 2, female_parent_line_id: evaluator.id)
-        plant_line_registry.plant_accessions = build_list(:plant_accession, 2, plant_line_id: evaluator.id)
-        # plant_line_registry.plant_populations = build_list(:plant_population, 2)
+      after(:create) do |plant_line, evaluator|
+        plant_line.fathered_descendants = build_list(:plant_population, 2, male_parent_line_id: evaluator.id)
+        plant_line.mothered_descendants = build_list(:plant_population, 2, female_parent_line_id: evaluator.id)
+        plant_line.plant_accessions = build_list(:plant_accession, 2, plant_line_id: evaluator.id)
+        # plant_line.plant_populations = build_list(:plant_population, 2)
 
-        plant_line_registry.plant_population_lists =
+        plant_line.plant_population_lists =
           build_list(:plant_population_list, 2, plant_line_id: evaluator.id)
+      end
+    end
+
+    trait :not_owned_by_user do
+      after(:create) do |plant_line, evaluator|
+        plant_line.update_column(:user_id, nil)
       end
     end
   end

--- a/spec/requests/api_spec.rb
+++ b/spec/requests/api_spec.rb
@@ -23,7 +23,8 @@ RSpec.describe "API V1" do
     let!(:plant_population) do
       create(:plant_population,
              user: user,
-             male_parent_line: parent_line
+             male_parent_line: parent_line,
+             published: false
       )
     end
     let!(:plant_population_list_1) do

--- a/spec/services/submission/plant_population_publisher_spec.rb
+++ b/spec/services/submission/plant_population_publisher_spec.rb
@@ -1,0 +1,91 @@
+require "rails_helper"
+
+RSpec.describe Submission::PlantPopulationPublisher do
+  let(:plant_population) { submission.submitted_object }
+  let(:user) { submission.user }
+
+  subject { described_class.new(submission) }
+
+  context "#publish" do
+    let(:submission) { create(:finalized_submission, :population) }
+    let!(:plant_lines) { create_list(:plant_line, 2, user: user, published: false) }
+    let!(:plant_population_lists) { [
+      create(:plant_population_list, plant_line: plant_lines[0],
+                                     plant_population: plant_population,
+                                     user: user, published: false),
+      create(:plant_population_list, plant_line: plant_lines[1],
+                                     user: user, published: false)
+    ] }
+
+    before { subject.publish }
+
+    it "publishes submitted plant population" do
+      expect(submission.reload).to be_publishable
+      expect(plant_population.reload).to be_published
+    end
+
+    it "publishes associated objects" do
+      expect(plant_population.plant_lines).to all(be_published)
+      expect(plant_population.plant_population_lists).to all(be_published)
+    end
+
+    it "does not modify objects not associated with given submission" do
+      expect(plant_population_lists[1].reload).not_to be_published
+      expect(plant_lines[1].reload).not_to be_published
+    end
+  end
+
+  context "#revoke" do
+    let(:submission) { create(:finalized_submission, :population, publishable: true) }
+
+    context "for revocable submission" do
+      let!(:plant_lines) { [
+        create(:plant_line, :not_owned_by_user, published: true),
+        create(:plant_line, user: user, published: true),
+        create(:plant_line, user: user, published: true)
+      ] }
+      let!(:plant_population_lists) { [
+        create(:plant_population_list, plant_line: plant_lines[0],
+                                       plant_population: plant_population,
+                                       user: user, published: true),
+        create(:plant_population_list, plant_line: plant_lines[1],
+                                       plant_population: plant_population,
+                                       user: user, published: true),
+        create(:plant_population_list, plant_line: plant_lines[2],
+                                       user: user, published: true)
+      ] }
+
+      before { subject.revoke }
+
+      it "revokes publication of submitted plant population" do
+        expect(submission.reload).not_to be_publishable
+        expect(plant_population.reload).not_to be_published
+      end
+
+      it "revokes publication of associated objects belonging to submission's owner" do
+        expect(plant_lines[1].reload).not_to be_published
+        expect(plant_population_lists[0].reload).not_to be_published
+        expect(plant_population_lists[1].reload).not_to be_published
+      end
+
+      it "does not modify objects not associated with given submission" do
+        expect(plant_lines[2].reload).to be_published
+        expect(plant_population_lists[2].reload).to be_published
+      end
+
+      it "does not modify objects not belonging to sumission's owner" do
+        expect(plant_lines[0].reload).to be_published
+      end
+    end
+
+    context "for irrevocable submission" do
+      before do
+        plant_population.update_column(:published_on, 7.days.ago)
+      end
+
+      it "fails" do
+        expect { subject.revoke }.to raise_error(/not revocable/)
+      end
+    end
+  end
+end

--- a/spec/services/submission/plant_population_publisher_spec.rb
+++ b/spec/services/submission/plant_population_publisher_spec.rb
@@ -73,6 +73,11 @@ RSpec.describe Submission::PlantPopulationPublisher do
         expect(plant_population_lists[2].reload).to be_published
       end
 
+      it "does not modify objects not associated with given submission" do
+        pending
+        fail
+      end
+
       it "does not modify objects not belonging to sumission's owner" do
         expect(plant_lines[0].reload).to be_published
       end

--- a/spec/services/submission/plant_trial_publisher_spec.rb
+++ b/spec/services/submission/plant_trial_publisher_spec.rb
@@ -1,0 +1,103 @@
+require "rails_helper"
+
+RSpec.describe Submission::PlantTrialPublisher do
+  let(:plant_trial) { submission.submitted_object }
+  let(:user) { submission.user }
+
+  subject { described_class.new(submission) }
+
+  context "#publish" do
+    let(:submission) { create(:finalized_submission, :trial) }
+    let!(:plant_scoring_units) { [
+      create(:plant_scoring_unit, published: false,
+                                  user: user,
+                                  plant_trial: plant_trial),
+      create(:plant_scoring_unit, published: false, user: user)
+    ] }
+    let!(:trait_descriptors) { [
+      create(:trait_descriptor, published: false, user: user),
+      create(:trait_descriptor, published: false, user: user),
+    ] }
+    let!(:trait_scores) { [
+      create(:trait_score, published: false, user: user,
+                           plant_scoring_unit: plant_scoring_units[0],
+                           trait_descriptor: trait_descriptors[0]),
+      create(:trait_score, published: false, user: user,
+                           plant_scoring_unit: plant_scoring_units[1],
+                           trait_descriptor: trait_descriptors[1])
+    ] }
+
+    before { subject.publish }
+
+    it "publishes submitted plant trial" do
+      expect(submission.reload).to be_publishable
+      expect(plant_trial.reload).to be_published
+    end
+
+    it "publishes associated objects" do
+      expect(plant_trial.plant_scoring_units).to all(be_published)
+      expect(plant_trial.plant_scoring_units.map(&:trait_scores).flatten).to all(be_published)
+      expect(trait_descriptors[0].reload).to be_published
+    end
+
+    it "does not modify objects not associated with given submission" do
+      expect(plant_scoring_units[1].reload).not_to be_published
+      expect(trait_descriptors[1].reload).not_to be_published
+      expect(trait_scores[1].reload).not_to be_published
+    end
+  end
+
+  context "#revoke" do
+    let(:submission) { create(:finalized_submission, :trial, publishable: true) }
+
+    context "for revocable submission" do
+      let!(:plant_scoring_units) { [
+        create(:plant_scoring_unit, published: true,
+                                    user: user,
+                                    plant_trial: plant_trial),
+        create(:plant_scoring_unit, published: true, user: user)
+      ] }
+      let!(:trait_descriptors) { [
+        create(:trait_descriptor, published: true, user: user),
+        create(:trait_descriptor, published: true, user: user),
+      ] }
+      let!(:trait_scores) { [
+        create(:trait_score, published: true, user: user,
+                             plant_scoring_unit: plant_scoring_units[0],
+                             trait_descriptor: trait_descriptors[0]),
+        create(:trait_score, published: true, user: user,
+                             plant_scoring_unit: plant_scoring_units[1],
+                             trait_descriptor: trait_descriptors[1])
+      ] }
+
+      before { subject.revoke }
+
+      it "revokes publication of submitted plant trial" do
+        expect(submission.reload).not_to be_publishable
+        expect(plant_trial.reload).not_to be_published
+      end
+
+      it "revokes publication of associated objects belonging to submission's owner" do
+        expect(plant_scoring_units[0].reload).not_to be_published
+        expect(trait_scores[0].reload).not_to be_published
+        expect(trait_descriptors[0].reload).not_to be_published
+      end
+
+      it "does not modify objects not associated with given submission" do
+        expect(plant_scoring_units[1].reload).to be_published
+        expect(trait_descriptors[1].reload).to be_published
+        expect(trait_scores[1].reload).to be_published
+      end
+    end
+
+    context "for irrevocable submission" do
+      before do
+        plant_trial.update_column(:published_on, 7.days.ago)
+      end
+
+      it "fails" do
+        expect { subject.revoke }.to raise_error(/not revocable/)
+      end
+    end
+  end
+end

--- a/spec/support/shared_examples/api_deletable_resource.rb
+++ b/spec/support/shared_examples/api_deletable_resource.rb
@@ -10,7 +10,7 @@ RSpec.shared_examples "API-deletable resource" do |model_klass|
 
     it 'returns true for private objects not older than 1 week, false otherwise' do
       subject.update_attributes!(published: false, published_on: nil)
-      expect(subject.reload.revocable?).to be_truthy
+      expect(subject.reload.revocable?).to be_falsey
 
       subject.update_attributes!(published: true, published_on: Time.now)
       expect(subject.reload.revocable?).to be_truthy


### PR DESCRIPTION
Fixes #453 

@Nuanda There are no specs yet but the logic is more or less complete, so you can have a look.

One (possibly minor) issue is that at present there is no easy way to tell which submission resulted in creation of an associated object. As a result changing visibility of one submission may affect visibility of some objects associated with another submission belonging to the same user.