### PR TITLE
Makes "Related" counters updated by number of invisible records

### DIFF
--- a/app/models/concerns/pluckable.rb
+++ b/app/models/concerns/pluckable.rb
@@ -13,10 +13,16 @@ module Pluckable extend ActiveSupport::Concern
   included do
     include Joinable
 
-    def self.pluck_columns
+    def self.pluck_columns(uid = nil)
       query = self.all
-      cc = respond_to?(:count_columns) ? count_columns : []
-      columns = table_columns + cc + ref_columns
+      # Detect Relatable models
+      count_columns = if self.respond_to?(:privacy_adjusted_count_columns)
+                        query = join_counters(query, uid)
+                        privacy_adjusted_count_columns
+                      else
+                        []
+                      end
+      columns = table_columns + count_columns + ref_columns
       query = join_columns(columns, query, true)
       query.pluck(*columns)
     end

--- a/app/models/concerns/publishable.rb
+++ b/app/models/concerns/publishable.rb
@@ -7,11 +7,15 @@ module Publishable
     validates_with PublicationValidator
 
     scope :visible, ->(uid = nil) {
-      if uid.present?
-        where("published = 't' OR user_id = #{uid}")
-      else
-        where("published = 't' OR user_id IS NULL")
-      end
+      condition = "#{table_name}.user_id IS NULL OR #{table_name}.published = TRUE"
+      condition += " OR #{table_name}.user_id = #{uid}" if uid
+      where condition
+    }
+
+    scope :hidden, ->(uid = nil) {
+      condition = "#{table_name}.published = FALSE"
+      condition += " AND #{table_name}.user_id <> #{uid}" if uid
+      where condition
     }
 
     def revocable?

--- a/app/models/concerns/relatable.rb
+++ b/app/models/concerns/relatable.rb
@@ -6,6 +6,9 @@
 #  - add 'ms_count' string to self.count_columns below
 #  - include Filterable in M
 #  - add 'this_models.id' to M.permitted_params for :query hash
+# If the model redefines its own table_data, you need to add the following there:
+#  - query = join_counters(query, uid)
+#  - use privacy_adjusted_count_columns in pluck (NOT simply count_columns)
 module Relatable extend ActiveSupport::Concern
   included do
     # Provides table_names for related, counted models
@@ -15,6 +18,34 @@ module Relatable extend ActiveSupport::Concern
       end
     end
 
+    def self.privacy_adjusted_count_columns
+      count_columns.map do |column|
+        counter_column = column.split(/ as /i)[0]
+        as_column = column.split(/ as /i)[-1]
+        "(#{table_name}.#{counter_column} - coalesce(#{get_related_model(counter_column)}.hidden, 0)) AS #{as_column}"
+      end
+    end
+
+    # Left outer joins all countable relations in order to deduct the number
+    # of 'hidden' records (i.e. related records that are not visible to the
+    # uid user).
+    def self.join_counters(query, uid = nil)
+      count_columns.each do |count_column|
+        relation = get_related_model(count_column.split(/ as /i)[0])
+        related_klass = adjust_related_name(relation).classify.constantize
+        fkey = reverse_relation_key(relation)
+        self_table = self.table_name
+        subquery = related_klass.hidden(uid).
+                                 group(fkey).
+                                 select{ [fkey, count(id).as(hidden)] }
+        query = query.joins{ subquery.
+                             as(relation).
+                             on{ __send__(relation).send(fkey).eq(__send__(self_table).send('id')) }.
+                             outer }
+      end
+      query
+    end
+
     def self.count_columns
       []
     end
@@ -22,19 +53,20 @@ module Relatable extend ActiveSupport::Concern
     private
 
     def self.get_related_model(counter_name)
-      counter_name.match(/\(([^\)]+)\)/) do |match|
-        counter_name = match[0][1..-2]  # remove aggregation function
-      end
       counter_name = counter_name.split(/ as /i)[-1]  # honor aliasing
       counter_name.gsub!('_count','')   # support cached count columns as well
-
       counter_name.gsub!('qtls','qtl')  # unfortunate special case... :(
+      counter_name
+    end
 
-      if counter_name.include? '.'
-        counter_name.split('.')[-1]
-      else
-        counter_name
-      end
+    def self.adjust_related_name(related_name)
+      related_name.end_with?('_a', '_b') ? related_name[0..-3] : related_name
+    end
+
+    def self.reverse_relation_key(forward_relation)
+      reverse_relation = self.name.underscore
+      reverse_relation += forward_relation[-2..-1] if forward_relation.end_with?('_a', '_b')
+      "#{reverse_relation}_id"
     end
   end
 end

--- a/app/models/concerns/table_data.rb
+++ b/app/models/concerns/table_data.rb
@@ -3,8 +3,8 @@ module TableData extend ActiveSupport::Concern
   included do
     def self.table_data(params = nil, uid = nil)
       query = (params && (params[:query] || params[:fetch])) ? filter(params) : all
-      query = query.where(arel_table[:user_id].eq(uid).or(arel_table[:published].eq(true)))
-      query.pluck_columns
+      query = query.merge(visible(uid))
+      query.pluck_columns(uid)
     end
   end
 end

--- a/app/models/marker_assay.rb
+++ b/app/models/marker_assay.rb
@@ -50,7 +50,9 @@ class MarkerAssay < ActiveRecord::Base
       ]}
     query = query.
       where(arel_table[:user_id].eq(uid).or(arel_table[:published].eq(true)))
-    query.pluck(*(table_columns + count_columns + ref_columns))
+
+    query = join_counters(query, uid)
+    query.pluck(*(table_columns + privacy_adjusted_count_columns + ref_columns))
   end
 
   def self.table_columns

--- a/app/models/marker_assay.rb
+++ b/app/models/marker_assay.rb
@@ -38,10 +38,6 @@ class MarkerAssay < ActiveRecord::Base
   include Publishable
 
   def self.table_data(params = nil, uid = nil)
-    ma = MarkerAssay.arel_table
-    pra = Primer.arel_table
-    pr = Probe.arel_table
-
     primer_subquery = Primer.visible(uid)
     probe_subquery = Probe.visible(uid)
 
@@ -53,7 +49,7 @@ class MarkerAssay < ActiveRecord::Base
         probe_subquery.as('probes').on { probe_id == probes.id }.outer
       ]}
     query = query.
-      where(ma[:user_id].eq(uid).or(ma[:published].eq(true)))
+      where(arel_table[:user_id].eq(uid).or(arel_table[:published].eq(true)))
     query.pluck(*(table_columns + count_columns + ref_columns))
   end
 

--- a/app/models/plant_line.rb
+++ b/app/models/plant_line.rb
@@ -19,6 +19,8 @@ class PlantLine < ActiveRecord::Base
   after_update { mothered_descendants.each(&:touch) }
   after_update { fathered_descendants.each(&:touch) }
 
+  after_update :cascade_visibility
+
   include Filterable
   include Pluckable
   include Searchable
@@ -77,4 +79,14 @@ class PlantLine < ActiveRecord::Base
   end
 
   include Annotable
+
+  private
+
+  def cascade_visibility
+    if published_changed?
+      plant_population_lists.each do |ppl|
+        ppl.update_attributes!(published: self.published?, published_on: Time.now)
+      end
+    end
+  end
 end

--- a/app/models/plant_population.rb
+++ b/app/models/plant_population.rb
@@ -21,6 +21,8 @@ class PlantPopulation < ActiveRecord::Base
   after_update { linkage_maps.each(&:touch) }
   after_update { plant_trials.each(&:touch) }
 
+  after_update :cascade_visibility
+
   include Relatable
   include Filterable
   include Searchable
@@ -107,4 +109,14 @@ class PlantPopulation < ActiveRecord::Base
   end
 
   include Annotable
+
+  private
+
+  def cascade_visibility
+    if published_changed?
+      plant_population_lists.each do |ppl|
+        ppl.update_attributes!(published: self.published?, published_on: Time.now)
+      end
+    end
+  end
 end

--- a/app/models/plant_population.rb
+++ b/app/models/plant_population.rb
@@ -48,8 +48,10 @@ class PlantPopulation < ActiveRecord::Base
       ]}
     query = query.
       where(arel_table[:user_id].eq(uid).or(arel_table[:published].eq(true)))
+
+    query = join_counters(query, uid)
     query = query.by_name
-    query.pluck(*(table_columns + count_columns + ref_columns))
+    query.pluck(*(table_columns + privacy_adjusted_count_columns + ref_columns))
   end
 
   def self.table_columns

--- a/app/models/plant_population.rb
+++ b/app/models/plant_population.rb
@@ -36,7 +36,6 @@ class PlantPopulation < ActiveRecord::Base
   scope :by_name, -> { order('plant_populations.name') }
 
   def self.table_data(params = nil, uid = nil)
-    pp = PlantPopulation.arel_table
     subquery = PlantLine.visible(uid)
 
     query = (params && (params[:query] || params[:fetch])) ? filter(params) : all
@@ -48,7 +47,7 @@ class PlantPopulation < ActiveRecord::Base
         population_type.outer
       ]}
     query = query.
-      where(pp[:user_id].eq(uid).or(pp[:published].eq(true)))
+      where(arel_table[:user_id].eq(uid).or(arel_table[:published].eq(true)))
     query = query.by_name
     query.pluck(*(table_columns + count_columns + ref_columns))
   end

--- a/app/models/qtl.rb
+++ b/app/models/qtl.rb
@@ -20,8 +20,6 @@ class Qtl < ActiveRecord::Base
   include Publishable
 
   def self.table_data(params = nil, uid = nil)
-    qtlt = Qtl.arel_table
-
     td_subquery = TraitDescriptor.visible(uid)
     lg_subquery = LinkageGroup.visible(uid)
     lm_subquery = LinkageMap.visible(uid)
@@ -39,7 +37,7 @@ class Qtl < ActiveRecord::Base
         pp_subquery.as('plant_populations').on { linkage_maps.plant_population_id == plant_populations.id }.outer,
         qtlj_subquery.as('qtl_jobs').on { qtl_job_id == qtl_jobs.id }.outer
       ]}
-    query = query.where(qtlt[:user_id].eq(uid).or(qtlt[:published].eq(true)))
+    query = query.where(arel_table[:user_id].eq(uid).or(arel_table[:published].eq(true)))
     query.pluck(*(table_columns + ref_columns))
   end
 

--- a/app/models/trait_score.rb
+++ b/app/models/trait_score.rb
@@ -16,8 +16,6 @@ class TraitScore < ActiveRecord::Base
   }
 
   def self.table_data(params = nil, uid = nil)
-    ts = TraitScore.arel_table
-
     psu_subquery = PlantScoringUnit.visible(uid)
     pt_subquery = PlantTrial.visible(uid)
     pp_subquery = PlantPopulation.visible(uid)
@@ -36,7 +34,7 @@ class TraitScore < ActiveRecord::Base
     ]}
 
     query = (params && (params[:query] || params[:fetch])) ? filter(params, query) : query
-    query = query.where(ts[:user_id].eq(uid).or(ts[:published].eq(true)))
+    query = query.where(arel_table[:user_id].eq(uid).or(arel_table[:published].eq(true)))
     query.pluck(*(table_columns + ref_columns))
   end
 

--- a/spec/models/concerns/relatable_spec.rb
+++ b/spec/models/concerns/relatable_spec.rb
@@ -1,15 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe Relatable do
-  before(:all) do
-    @relatable_models = relatable_models
-    @countable_models = @relatable_models.map do |model|
-      model.counter_names.map do |counter_name|
-        counter_name.end_with?('_a', '_b') ? counter_name[0..-3] : counter_name
-      end
-    end.flatten.uniq
-  end
-
   it 'makes sure the cached counters work' do
     pp = create(:plant_population,
                 linkage_maps: create_list(:linkage_map, 3, plant_population: nil))
@@ -24,25 +15,75 @@ RSpec.describe Relatable do
     expect(pp.reload.linkage_maps_count).to eq 2
   end
 
-  it 'there exist relatable models' do
-    expect(@relatable_models).not_to be_empty
-  end
-
   it 'requires all related models to be Filterable' do
+    @countable_models = relatable_models.map do |model|
+      model.counter_names.map do |counter_name|
+        adjust_counter_name counter_name
+      end
+    end.flatten.uniq
     @countable_models.each do |model|
       expect(model.classify.constantize).to include Filterable
     end
   end
 
-  it 'requires all related models to allow correct filter param' do
-    @relatable_models.each do |master_model|
-      next if master_model == Primer
-      master_model.counter_names.each do |model|
-        permitted_params = model.classify.constantize.send(:permitted_params)
-        expect(permitted_params).not_to be_empty
-        expect(permitted_params.dup.extract_options![:query]).
-          to include "#{master_model.table_name}.id"
+  context 'for all Relatable models' do
+    relatable_models.each do |klass|
+      klass.count_columns.each_with_index do |count_column, i|
+        relation = count_column.split(/ as /i)[0]
+        relation.gsub!('_count','')
+        relation = 'qtls' if relation == 'qtl'  # unfortunate special case... :(
+        it "does not count inaccessible #{relation} records related to #{klass}" do
+          model = adjust_model(klass.name.underscore, relation)
+          related = create(adjust_counter_name(relation).singularize)
+          subject = related.send(model)
+          create(adjust_counter_name(relation).singularize,
+                 model => subject, published: false)
+
+          expect(subject.send(relation).count).to eq 2
+          expect(subject.reload.send("#{relation}_count")).to eq 2
+
+          td = klass.table_data.detect{ |row| row.last == subject.id }
+          expect(td).not_to be_empty
+          index = - klass.ref_columns.size - klass.count_columns.size + i
+          expect(td[index]).to eq 1
+        end
+
+        it "counts in private owned #{relation} records for #{klass}" do
+          model = adjust_model(klass.name.underscore, relation)
+          related = create(adjust_counter_name(relation).singularize)
+          subject = related.send(model)
+          owned = create(adjust_counter_name(relation).singularize,
+                         model => subject, published: false, user: create(:user))
+
+          expect(subject.send(relation).count).to eq 2
+          expect(subject.reload.send("#{relation}_count")).to eq 2
+
+          td = klass.table_data(nil, owned.user_id).detect{ |row| row.last == subject.id }
+          expect(td).not_to be_empty
+          index = - klass.ref_columns.size - klass.count_columns.size + i
+          expect(td[index]).to eq 2
+        end
+
+        it "requires all models related to #{klass} to allow correct filter param" do
+          next if klass == Primer
+          klass.counter_names.each do |model|
+            permitted_params = model.classify.constantize.send(:permitted_params)
+            expect(permitted_params).not_to be_empty
+            expect(permitted_params.dup.extract_options![:query]).
+                to include "#{klass.table_name}.id"
+          end
+        end
       end
     end
+  end
+
+  private
+
+  def adjust_counter_name(counter_name)
+    counter_name.end_with?('_a', '_b') ? counter_name[0..-3] : counter_name
+  end
+
+  def adjust_model(model, relation)
+    model + (relation.end_with?('_a', '_b') ? relation[-2..-1] : '')
   end
 end

--- a/spec/models/plant_line_spec.rb
+++ b/spec/models/plant_line_spec.rb
@@ -146,4 +146,21 @@ RSpec.describe PlantLine do
       expect(td.map(&:second)).to eq pls.map(&:plant_line_name).sort
     end
   end
+
+  describe '#cascade_visibility' do
+    it 'changes visibility of all related plant population lists' do
+      pl = create(:plant_line, user: create(:user), published: false)
+      create_list(:plant_population_list, 2, plant_line: pl, user: pl.user, published: false)
+
+      expect { pl.update_attribute(:published, true) }.
+        to change { PlantPopulationList.visible(nil).count }.by(2)
+    end
+
+    it 'does nothing when there is no visibility change' do
+      expect_any_instance_of(PlantPopulationList).not_to receive(:update_attributes!)
+      pl = create(:plant_line, user: create(:user), published: false)
+      create(:plant_population_list, plant_line: pl, user: pl.user, published: false)
+      pl.update_attribute(:plant_line_name, 'some other name')
+    end
+  end
 end

--- a/spec/models/plant_population_spec.rb
+++ b/spec/models/plant_population_spec.rb
@@ -109,4 +109,21 @@ RSpec.describe PlantPopulation do
       expect(gd.count).to eq 3
     end
   end
+
+  describe '#cascade_visibility' do
+    it 'changes visibility of all related plant population lists' do
+      pp = create(:plant_population, user: create(:user), published: false)
+      create_list(:plant_population_list, 2, plant_population: pp, user: pp.user, published: false)
+
+      expect { pp.update_attribute(:published, true) }.
+          to change { PlantPopulationList.visible(nil).count }.by(2)
+    end
+
+    it 'does nothing when there is no visibility change' do
+      expect_any_instance_of(PlantPopulationList).not_to receive(:update_attributes!)
+      pp = create(:plant_population, user: create(:user), published: false)
+      create(:plant_population_list, plant_population: pp, user: pp.user, published: false)
+      pp.update_attribute(:name, 'some other name')
+    end
+  end
 end


### PR DESCRIPTION
Fixes #456 

The visibility of the related records depends on the usual algorithm. Counters should be updated correctly.