### PR TITLE
Invalidation of cache on different user and when related records are modified

### DIFF
--- a/app/controllers/data_tables_controller.rb
+++ b/app/controllers/data_tables_controller.rb
@@ -9,6 +9,7 @@ class DataTablesController < ApplicationController
         cache_key = params.reject{ |k,_| %w(_ controller action format).include? k }
         cache_key[:latest_change] = model_klass.maximum('updated_at')
         cache_key[:count] = model_klass.count
+        cache_key[:user_id] = current_user.try(:id)
         logger.info "CACHE KEY: #{cache_key}"
         grid_data = Rails.cache.fetch(cache_key, expires_in: 300.days) do
           logger.info 'MISS MISS MISS'

--- a/app/models/linkage_group.rb
+++ b/app/models/linkage_group.rb
@@ -1,6 +1,13 @@
 class LinkageGroup < ActiveRecord::Base
-  belongs_to :linkage_map, counter_cache: true
+  belongs_to :linkage_map, counter_cache: true, touch: true
   belongs_to :user
+
+  after_update { map_positions.each(&:touch) }
+  after_update { map_locus_hits.each(&:touch) }
+  after_update { qtls.each(&:touch) }
+  before_destroy { map_positions.each(&:touch) }
+  before_destroy { map_locus_hits.each(&:touch) }
+  before_destroy { qtls.each(&:touch) }
 
   has_many :map_positions
   has_many :map_locus_hits
@@ -15,10 +22,6 @@ class LinkageGroup < ActiveRecord::Base
 
   validates :consensus_group_assignment,
             presence: true
-
-  after_update { map_positions.each(&:touch) }
-  after_update { map_locus_hits.each(&:touch) }
-  after_update { qtls.each(&:touch) }
 
   include Relatable
   include Filterable

--- a/app/models/linkage_map.rb
+++ b/app/models/linkage_map.rb
@@ -2,6 +2,11 @@ class LinkageMap < ActiveRecord::Base
   belongs_to :plant_population, counter_cache: true, touch: true
   belongs_to :user
 
+  after_update { map_locus_hits.each(&:touch) }
+  after_update { linkage_groups.each(&:touch) }
+  before_destroy { map_locus_hits.each(&:touch) }
+  before_destroy { linkage_groups.each(&:touch) }
+
   has_many :linkage_groups
   has_many :genotype_matrices
   has_many :map_locus_hits
@@ -17,8 +22,6 @@ class LinkageMap < ActiveRecord::Base
   validates :map_version_no,
             presence: true,
             length: { minimum: 1, maximum: 3 }
-
-  after_update { map_locus_hits.each(&:touch) }
 
   default_scope { includes(plant_population: :taxonomy_term) }
 

--- a/app/models/map_locus_hit.rb
+++ b/app/models/map_locus_hit.rb
@@ -1,20 +1,14 @@
 class MapLocusHit < ActiveRecord::Base
-  belongs_to :linkage_map, counter_cache: true
-  belongs_to :linkage_group, counter_cache: true
-  belongs_to :map_position, counter_cache: true
-  belongs_to :population_locus, counter_cache: true
+  belongs_to :linkage_map, counter_cache: true, touch: true
+  belongs_to :linkage_group, counter_cache: true, touch: true
+  belongs_to :map_position, counter_cache: true, touch: true
+  belongs_to :population_locus, counter_cache: true, touch: true
   belongs_to :user
 
   validates :consensus_group_assignment,
-            presence: true
-
-  validates :canonical_marker_name,
-            presence: true
-
-  validates :associated_sequence_id,
-            presence: true
-
-  validates :sequence_source_acronym,
+            :canonical_marker_name,
+            :associated_sequence_id,
+            :sequence_source_acronym,
             presence: true
 
   include Filterable

--- a/app/models/map_position.rb
+++ b/app/models/map_position.rb
@@ -1,15 +1,15 @@
 class MapPosition < ActiveRecord::Base
-  belongs_to :linkage_group, counter_cache: true
-  belongs_to :population_locus, counter_cache: true
-  belongs_to :marker_assay, counter_cache: true
+  belongs_to :linkage_group, counter_cache: true, touch: true
+  belongs_to :population_locus, counter_cache: true, touch: true
+  belongs_to :marker_assay, counter_cache: true, touch: true
   belongs_to :user
+
+  after_update { map_locus_hits.each(&:touch) }
+  before_destroy { map_locus_hits.each(&:touch) }
 
   has_many :map_locus_hits
 
-  validates :map_position,
-            presence: true
-
-  after_update { map_locus_hits.each(&:touch) }
+  validates :map_position, presence: true
 
   include Relatable
   include Filterable

--- a/app/models/marker_assay.rb
+++ b/app/models/marker_assay.rb
@@ -11,14 +11,21 @@ class MarkerAssay < ActiveRecord::Base
   belongs_to :primer_a,
              class_name: 'Primer',
              foreign_key: 'primer_a_id',
-             counter_cache: 'marker_assays_a_count'
+             counter_cache: 'marker_assays_a_count',
+             touch: true
   belongs_to :primer_b,
              class_name: 'Primer',
              foreign_key: 'primer_b_id',
-             counter_cache: 'marker_assays_b_count'
+             counter_cache: 'marker_assays_b_count',
+             touch: true
 
-  belongs_to :probe, counter_cache: true
+  belongs_to :probe, counter_cache: true, touch: true
   belongs_to :user
+
+  after_update { population_loci.each(&:touch) }
+  after_update { map_positions.each(&:touch) }
+  before_destroy { population_loci.each(&:touch) }
+  before_destroy { map_positions.each(&:touch) }
 
   has_many :population_loci
   has_many :map_positions
@@ -29,8 +36,6 @@ class MarkerAssay < ActiveRecord::Base
 
   validates :canonical_marker_name,
             presence: true
-
-  after_update { population_loci.each(&:touch) }
 
   include Searchable
   include Relatable

--- a/app/models/marker_assay.rb
+++ b/app/models/marker_assay.rb
@@ -44,8 +44,6 @@ class MarkerAssay < ActiveRecord::Base
 
   def self.table_data(params = nil, uid = nil)
     ma = MarkerAssay.arel_table
-    pra = Primer.arel_table
-    pr = Probe.arel_table
 
     primer_subquery = Primer.visible(uid)
     probe_subquery = Probe.visible(uid)

--- a/app/models/plant_accession.rb
+++ b/app/models/plant_accession.rb
@@ -2,6 +2,9 @@ class PlantAccession < ActiveRecord::Base
   belongs_to :plant_line
   belongs_to :user
 
+  after_update { plant_scoring_units.each(&:touch) }
+  before_destroy { plant_scoring_units.each(&:touch) }
+
   has_many :plant_scoring_units
 
   validates :plant_accession,

--- a/app/models/plant_line.rb
+++ b/app/models/plant_line.rb
@@ -3,21 +3,21 @@ class PlantLine < ActiveRecord::Base
   belongs_to :taxonomy_term
   belongs_to :user
 
-  has_many :fathered_descendants, class_name: 'PlantPopulation',
-           foreign_key: 'male_parent_line_id',
-           dependent: :nullify
-  has_many :mothered_descendants, class_name: 'PlantPopulation',
-           foreign_key: 'female_parent_line_id',
-           dependent: :nullify
-  has_many :plant_accessions,
-           dependent: :nullify
-
-  has_many :plant_population_lists, dependent: :delete_all
-  has_many :plant_populations,
-           through: :plant_population_lists
-
+  before_destroy { mothered_descendants.each(&:touch) }
+  before_destroy { fathered_descendants.each(&:touch) }
+  before_destroy { plant_accessions.each(&:touch) }
   after_update { mothered_descendants.each(&:touch) }
   after_update { fathered_descendants.each(&:touch) }
+  after_update { plant_accessions.each(&:touch) }
+
+  has_many :fathered_descendants, class_name: 'PlantPopulation',
+           foreign_key: 'male_parent_line_id'
+  has_many :mothered_descendants, class_name: 'PlantPopulation',
+           foreign_key: 'female_parent_line_id'
+  has_many :plant_accessions
+
+  has_many :plant_population_lists, dependent: :delete_all
+  has_many :plant_populations, through: :plant_population_lists
 
   include Filterable
   include Pluckable

--- a/app/models/plant_population.rb
+++ b/app/models/plant_population.rb
@@ -7,26 +7,22 @@ class PlantPopulation < ActiveRecord::Base
              foreign_key: 'female_parent_line_id'
   belongs_to :user
 
-  has_many :linkage_maps,
-           dependent: :nullify
-  has_many :population_loci,
-           dependent: :nullify
-  has_many :plant_trials,
-           dependent: :nullify
-
-  has_many :plant_population_lists, dependent: :delete_all
-  has_many :plant_lines,
-           through: :plant_population_lists
-
-  validates :name,
-            presence: true,
-            uniqueness: true
-  validates :user,
-            presence: { on: :create }
-
   after_update { population_loci.each(&:touch) }
   after_update { linkage_maps.each(&:touch) }
   after_update { plant_trials.each(&:touch) }
+  before_destroy { population_loci.each(&:touch) }
+  before_destroy { linkage_maps.each(&:touch) }
+  before_destroy { plant_trials.each(&:touch) }
+
+  has_many :linkage_maps
+  has_many :population_loci
+  has_many :plant_trials
+
+  has_many :plant_population_lists, dependent: :delete_all
+  has_many :plant_lines, through: :plant_population_lists
+
+  validates :name, presence: true, uniqueness: true
+  validates :user, presence: { on: :create }
 
   include Relatable
   include Filterable

--- a/app/models/plant_population.rb
+++ b/app/models/plant_population.rb
@@ -7,6 +7,13 @@ class PlantPopulation < ActiveRecord::Base
              foreign_key: 'female_parent_line_id'
   belongs_to :user
 
+  after_update { population_loci.each(&:touch) }
+  after_update { linkage_maps.each(&:touch) }
+  after_update { plant_trials.each(&:touch) }
+  before_destroy { population_loci.each(&:touch) }
+  before_destroy { linkage_maps.each(&:touch) }
+  before_destroy { plant_trials.each(&:touch) }
+
   has_many :linkage_maps, dependent: :nullify
   has_many :population_loci, dependent: :nullify
   has_many :plant_trials, dependent: :nullify
@@ -16,13 +23,6 @@ class PlantPopulation < ActiveRecord::Base
 
   validates :name, presence: true, uniqueness: true
   validates :user, presence: { on: :create }
-
-  after_update { population_loci.each(&:touch) }
-  after_update { linkage_maps.each(&:touch) }
-  after_update { plant_trials.each(&:touch) }
-  before_destroy { population_loci.each(&:touch) }
-  before_destroy { linkage_maps.each(&:touch) }
-  before_destroy { plant_trials.each(&:touch) }
 
   after_update :cascade_visibility
 

--- a/app/models/plant_population_list.rb
+++ b/app/models/plant_population_list.rb
@@ -1,6 +1,6 @@
 class PlantPopulationList < ActiveRecord::Base
   belongs_to :plant_line
-  belongs_to :plant_population, counter_cache: true
+  belongs_to :plant_population, counter_cache: true, touch: true
   belongs_to :user
 
   validates :plant_line_id,

--- a/app/models/plant_scoring_unit.rb
+++ b/app/models/plant_scoring_unit.rb
@@ -1,7 +1,7 @@
 class PlantScoringUnit < ActiveRecord::Base
   belongs_to :design_factor
-  belongs_to :plant_trial, counter_cache: true
-  belongs_to :plant_accession, counter_cache: true
+  belongs_to :plant_trial, counter_cache: true, touch: true
+  belongs_to :plant_accession, counter_cache: true, touch: true
   belongs_to :plant_part
   belongs_to :user
 

--- a/app/models/plant_trial.rb
+++ b/app/models/plant_trial.rb
@@ -1,7 +1,9 @@
 class PlantTrial < ActiveRecord::Base
-  belongs_to :plant_population, counter_cache: true
+  belongs_to :plant_population, counter_cache: true, touch: true
   belongs_to :country
   belongs_to :user
+
+  after_update { plant_scoring_units.each(&:touch) }
 
   has_many :plant_scoring_units, dependent: :destroy
   has_many :processed_trait_datasets

--- a/app/models/plant_variety.rb
+++ b/app/models/plant_variety.rb
@@ -9,6 +9,9 @@ class PlantVariety < ActiveRecord::Base
                           class_name: 'Country',
                           join_table: 'plant_variety_country_registered'
 
+  after_update { plant_lines.each(&:touch) }
+  before_destroy { plant_lines.each(&:touch) }
+
   has_many :plant_lines
 
   validates :plant_variety_name,

--- a/app/models/population_locus.rb
+++ b/app/models/population_locus.rb
@@ -1,16 +1,17 @@
 class PopulationLocus < ActiveRecord::Base
-  belongs_to :plant_population, counter_cache: true
-  belongs_to :marker_assay, counter_cache: true
+  belongs_to :plant_population, counter_cache: true, touch: true
+  belongs_to :marker_assay, counter_cache: true, touch: true
   belongs_to :user
+
+  after_update { map_positions.each(&:touch) }
+  after_update { map_locus_hits.each(&:touch) }
+  before_destroy { map_positions.each(&:touch) }
+  before_destroy { map_locus_hits.each(&:touch) }
 
   has_many :map_positions
   has_many :map_locus_hits
 
-  validates :mapping_locus,
-            presence: true
-
-  after_update { map_positions.each(&:touch) }
-  after_update { map_locus_hits.each(&:touch) }
+  validates :mapping_locus, presence: true
 
   include Relatable
   include Filterable

--- a/app/models/primer.rb
+++ b/app/models/primer.rb
@@ -1,6 +1,11 @@
 class Primer < ActiveRecord::Base
   belongs_to :user
 
+  after_update { marker_assays_a.each(&:touch) }
+  after_update { marker_assays_b.each(&:touch) }
+  before_destroy { marker_assays_a.each(&:touch) }
+  before_destroy { marker_assays_b.each(&:touch) }
+
   has_many :marker_assays_a,
            class_name: 'MarkerAssay',
            foreign_key: 'primer_a_id'
@@ -8,19 +13,12 @@ class Primer < ActiveRecord::Base
            class_name: 'MarkerAssay',
            foreign_key: 'primer_b_id'
 
-  validates :primer,
-            presence: true,
-            uniqueness: true
-
-  validates :sequence,
-            presence: true
+  validates :primer, presence: true, uniqueness: true
+  validates :sequence, presence: true
 
   def marker_assays
     marker_assays_a | marker_assays_b
   end
-
-  after_update { marker_assays_a.each(&:touch) }
-  after_update { marker_assays_b.each(&:touch) }
 
   include Searchable
   include Relatable

--- a/app/models/probe.rb
+++ b/app/models/probe.rb
@@ -2,22 +2,17 @@ class Probe < ActiveRecord::Base
   belongs_to :taxonomy_term
   belongs_to :user
 
+  after_update { marker_assays.each(&:touch) }
+  before_destroy { marker_assays.each(&:touch) }
+
   has_many :marker_assays
 
   validates :probe_name,
             presence: true,
             uniqueness: true
 
-  validates :clone_name,
+  validates :clone_name, :sequence_id, :sequence_source_acronym,
             presence: true
-
-  validates :sequence_id,
-            presence: true
-
-  validates :sequence_source_acronym,
-            presence: true
-
-  after_update { marker_assays.each(&:touch) }
 
   include Searchable
   include Relatable

--- a/app/models/processed_trait_dataset.rb
+++ b/app/models/processed_trait_dataset.rb
@@ -2,13 +2,14 @@ class ProcessedTraitDataset < ActiveRecord::Base
   belongs_to :plant_trial
   belongs_to :trait_descriptor
 
+  after_touch { qtls.each(&:touch) }
+  before_destroy { qtls.each(&:touch) }
+
   has_many :qtls
 
   validates :processed_trait_dataset_name,
             presence: true,
             uniqueness: true
-
-  after_touch { qtls.each(&:touch) }
 
   include Annotable
 end

--- a/app/models/qtl.rb
+++ b/app/models/qtl.rb
@@ -2,17 +2,11 @@ class Qtl < ActiveRecord::Base
   self.table_name = 'qtl'
 
   belongs_to :processed_trait_dataset
-  belongs_to :linkage_group, counter_cache: true
-  belongs_to :qtl_job, counter_cache: true
+  belongs_to :linkage_group, counter_cache: true, touch: true
+  belongs_to :qtl_job, counter_cache: true, touch: true
   belongs_to :user
 
-  validates :qtl_rank,
-            presence: true
-
-  validates :map_qtl_label,
-            presence: true
-
-  validates :qtl_mid_position,
+  validates :qtl_rank, :map_qtl_label, :qtl_mid_position,
             presence: true
 
   include Filterable

--- a/app/models/qtl_job.rb
+++ b/app/models/qtl_job.rb
@@ -2,16 +2,16 @@ class QtlJob < ActiveRecord::Base
   belongs_to :linkage_map
   belongs_to :user
 
+  after_update { qtls.each(&:touch) }
+  before_destroy { qtls.each(&:touch) }
+
   has_many :qtls
 
   validates :qtl_job_name,
             presence: true,
             uniqueness: true
 
-  validates :qtl_software,
-            presence: true
-
-  validates :qtl_method,
+  validates :qtl_software, :qtl_method,
             presence: true
 
   include Relatable

--- a/app/models/taxonomy_term.rb
+++ b/app/models/taxonomy_term.rb
@@ -4,9 +4,7 @@ class TaxonomyTerm < ActiveRecord::Base
              foreign_key: 'taxonomy_term_id'
 
   has_many :plant_lines
-
   has_many :plant_populations
-
   has_many :probes
 
   validates :name, uniqueness: true

--- a/app/models/trait_descriptor.rb
+++ b/app/models/trait_descriptor.rb
@@ -1,13 +1,14 @@
 class TraitDescriptor < ActiveRecord::Base
   belongs_to :user
 
+  after_update { processed_trait_datasets.each(&:touch) }
+  before_destroy { processed_trait_datasets.each(&:touch) }
+
   has_many :trait_grades
   has_many :trait_scores
   has_many :processed_trait_datasets
 
   validates :descriptor_name, :category, presence: true
-
-  after_update { processed_trait_datasets.each(&:touch) }
 
   include Searchable
   include AttributeValues

--- a/app/models/trait_score.rb
+++ b/app/models/trait_score.rb
@@ -1,10 +1,9 @@
 class TraitScore < ActiveRecord::Base
-  belongs_to :plant_scoring_unit, counter_cache: true
-  belongs_to :trait_descriptor, counter_cache: true
+  belongs_to :plant_scoring_unit, counter_cache: true, touch: true
+  belongs_to :trait_descriptor, counter_cache: true, touch: true
   belongs_to :user
 
-  validates :score_value,
-            presence: true
+  validates :score_value, presence: true
 
   include Filterable
   include Pluckable

--- a/spec/controllers/data_tables_controller_spec.rb
+++ b/spec/controllers/data_tables_controller_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe DataTablesController do
           expect(json['data'][0][3]).to be_nil
         end
 
-        it 'refreshes cache when a has_many related object disappear' do
+        it 'refreshes cache when a has_many related object disappears' do
           pt = create(:plant_trial)
           pt.plant_population.update_column(:updated_at, Time.now - 5.seconds)
           expect(PlantPopulation).to receive(:table_data).twice.and_call_original
@@ -133,6 +133,25 @@ RSpec.describe DataTablesController do
           json = JSON.parse(response.body)
           expect(json['recordsTotal']).to eq 1
           expect(json['data'][0][-5]).to eq 0
+        end
+
+        it "refreshes cache when a has_many related object appears" do
+          pp = create(:plant_population)
+          pp.update_column(:updated_at, Time.now - 5.seconds)
+
+          expect(PlantPopulation).to receive(:table_data).twice.and_call_original
+
+          get :index, format: :json, model: 'plant_populations'
+          json = JSON.parse(response.body)
+          expect(json['recordsTotal']).to eq 1
+          expect(json['data'][0][-5]).to eq 0
+
+          create(:plant_trial, plant_population: pp)
+
+          get :index, format: :json, model: 'plant_populations'
+          json = JSON.parse(response.body)
+          expect(json['recordsTotal']).to eq 1
+          expect(json['data'][0][-5]).to eq 1
         end
       end
     end

--- a/spec/controllers/data_tables_controller_spec.rb
+++ b/spec/controllers/data_tables_controller_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe DataTablesController do
   context 'when unauthenticated' do
-    context '#index' do
+    describe '#index' do
       it 'requires model param to work' do
         expect{ get(:index) }.
           to raise_error ActionController::ParameterMissing
@@ -73,6 +73,68 @@ RSpec.describe DataTablesController do
         expect(json['data'].size).to eq 0
         expect(json['data']).to eq []
       end
+
+      context 'when using cache' do
+        before(:each) { Rails.cache.clear }
+
+        it 'caches response when nothing new happened' do
+          expect(PlantLine).to receive(:table_data).once.and_return([])
+          get :index, format: :json, model: 'plant_lines'
+          get :index, format: :json, model: 'plant_lines'
+        end
+
+        it 'refreshes cache when a new object appears' do
+          expect(PlantLine).to receive(:table_data).twice.and_return([])
+          get :index, format: :json, model: 'plant_lines'
+          create(:plant_line)
+          get :index, format: :json, model: 'plant_lines'
+        end
+
+        it 'refreshes cache when a belongs_to related object disappears' do
+          pp = create(:plant_population, male_parent_line: nil)
+          pp.update_column(:updated_at, Time.now - 5.seconds)
+          expect(PlantPopulation).to receive(:table_data).twice.and_call_original
+          get :index, format: :json, model: 'plant_populations'
+          json = JSON.parse(response.body)
+          expect(json['recordsTotal']).to eq 1
+          expect(json['data'][0][3]).to eq PlantLine.first.plant_line_name
+          PlantLine.first.destroy
+          get :index, format: :json, model: 'plant_populations'
+          json = JSON.parse(response.body)
+          expect(json['recordsTotal']).to eq 1
+          expect(json['data'][0][3]).to be_nil
+        end
+
+        it 'refreshes cache when a belongs_to related object changes' do
+          pp = create(:plant_population, male_parent_line: nil)
+          pp.update_column(:updated_at, Time.now - 5.seconds)
+          expect(PlantPopulation).to receive(:table_data).twice.and_call_original
+          get :index, format: :json, model: 'plant_populations'
+          json = JSON.parse(response.body)
+          expect(json['recordsTotal']).to eq 1
+          expect(json['data'][0][3]).to eq PlantLine.first.plant_line_name
+          PlantLine.first.update_attribute :published, false
+          get :index, format: :json, model: 'plant_populations'
+          json = JSON.parse(response.body)
+          expect(json['recordsTotal']).to eq 1
+          expect(json['data'][0][3]).to be_nil
+        end
+
+        it 'refreshes cache when a has_many related object disappear' do
+          pt = create(:plant_trial)
+          pt.plant_population.update_column(:updated_at, Time.now - 5.seconds)
+          expect(PlantPopulation).to receive(:table_data).twice.and_call_original
+          get :index, format: :json, model: 'plant_populations'
+          json = JSON.parse(response.body)
+          expect(json['recordsTotal']).to eq 1
+          expect(json['data'][0][-5]).to eq 1
+          pt.destroy
+          get :index, format: :json, model: 'plant_populations'
+          json = JSON.parse(response.body)
+          expect(json['recordsTotal']).to eq 1
+          expect(json['data'][0][-5]).to eq 0
+        end
+      end
     end
 
     describe '#show' do
@@ -94,18 +156,33 @@ RSpec.describe DataTablesController do
 
     before { sign_in u1 }
 
-    it 'returns datatables json on json format request' do
-      pp1 = create(:plant_population, published: true, user: u2)
-      pp2 = create(:plant_population, published: false, user: u1)
-      pp3 = create(:plant_population, published: false, user: u2)
+    describe '#index' do
+      it 'returns datatables json on json format request' do
+        pp1 = create(:plant_population, published: true, user: u2)
+        pp2 = create(:plant_population, published: false, user: u1)
+        pp3 = create(:plant_population, published: false, user: u2)
 
-      get :index, format: :json, model: 'plant_populations'
-      expect(response.content_type).to eq 'application/json'
-      json = JSON.parse(response.body)
+        get :index, format: :json, model: 'plant_populations'
+        expect(response.content_type).to eq 'application/json'
+        json = JSON.parse(response.body)
 
-      expect(json['recordsTotal']).to eq 2
-      expect(json['data'].size).to eq 2
-      expect(json['data'].map(&:last)).to match_array [pp1, pp2].map(&:id)
+        expect(json['recordsTotal']).to eq 2
+        expect(json['data'].size).to eq 2
+        expect(json['data'].map(&:last)).to match_array [pp1, pp2].map(&:id)
+      end
+
+      context 'when using cache' do
+        before(:each) { Rails.cache.clear }
+
+        it 'uses different cache key for different user' do
+          expect(PlantLine).to receive(:table_data).thrice.and_return([])
+          get :index, format: :json, model: 'plant_lines'
+          sign_out u1
+          get :index, format: :json, model: 'plant_lines'
+          sign_in u2
+          get :index, format: :json, model: 'plant_lines'
+        end
+      end
     end
   end
 end

--- a/spec/models/plant_trial_spec.rb
+++ b/spec/models/plant_trial_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe PlantTrial do
+  it { should belong_to(:plant_population).touch(true) }
+
   describe '#filter' do
     it 'allow queries by project_descriptor' do
       pts = create_list(:plant_trial, 2)


### PR DESCRIPTION
Fixes #390 

It's still not perfect but better than it was. It's not only about privacy but rather about relations. Now I try to invalidate cache:
 - when a different user sees the data (per-user-cache)
 - when Related objects change (disappeared, were hidden)
 - when joined objects that have columns listed in the relating object view, change (or a re removed).

Sometimes we have joins traversing several models and this is not supported (I don't believe 'touch' executes callbacks and it means no cascading touches).

'before_destroy' is used since otherwise fkeys are already nullified, and it also needs to be before has_many (which, I believe, adds its default :nullify as another 'before_destroy' callback).

I provide only a single case testing as all-cases generic testing is rather tricky to write and would make specs dragging too much.

At the end of the day, if time and budget permits, we'll probably go for server-side, paginated responses, which will make tables caching not that important.