### PR TITLE
Block users getting other's private data

### DIFF
--- a/app/views/application/api.html.haml
+++ b/app/views/application/api.html.haml
@@ -70,6 +70,10 @@
         to filter results. These parameters are specific for each
         resource and will be described in detail later on.
 
+      %p
+        If a resource is owned by another BIP user, and is set as <i>not published</i>,
+        you will not be able to fetch it.
+
       %p Fetching multiple resources always yields paginated results.
 
       = api_props('Pagination parameters', 'pagination.params',

--- a/spec/support/shared_examples/api_deletable_resource.rb
+++ b/spec/support/shared_examples/api_deletable_resource.rb
@@ -71,6 +71,18 @@ RSpec.shared_examples "API-deletable resource" do |model_klass|
         expect(response.status).to eq 204
       end
 
+      it 'prevents destroying forbidden resource' do
+        subject.update_attributes!(published: false)
+        expect {
+          delete "/api/v1/#{model_name.pluralize}/#{subject.id}", {}, { "X-BIP-Api-Key" => create(:api_key).token }
+        }.to change {
+          model_klass.count
+        }.by(0)
+
+        expect(response.status).to eq 401
+        expect(parsed_response['reason']).not_to be_empty
+      end
+
       it 'returns 404 for nonexistent resource' do
         expect {
           delete "/api/v1/#{model_name.pluralize}/505505", {}, { "X-BIP-Api-Key" => api_key.token }

--- a/spec/support/shared_examples/api_readable_resource.rb
+++ b/spec/support/shared_examples/api_readable_resource.rb
@@ -183,8 +183,13 @@ RSpec.shared_examples "API-readable resource" do |model_klass|
         end
         get "/api/v1/#{model_name.pluralize}/#{resource.id}", { }, { "X-BIP-Api-Key" => api_key.token }
 
-        expect(parsed_response).
-          to resource.has_attribute?(:published) ? be_empty : have_key(model_name)
+        if resource.has_attribute?(:published)
+          expect(response.status).to eq 401
+          expect(parsed_response['reason']).
+            to eq 'This is a private resource of another user'
+        else
+          expect(parsed_response).to have_key(model_name)
+        end
       end
 
       context 'when run for Relatable model' do

--- a/spec/support/shared_examples/api_writable_resource.rb
+++ b/spec/support/shared_examples/api_writable_resource.rb
@@ -91,6 +91,9 @@ RSpec.shared_examples "API-writable resource" do |model_klass|
           expect(response).to be_success
           expect(parsed_response[model_name]['date_entered']).to eq Date.today.to_s
           expect(parsed_response[model_name]['entered_by_whom']).to eq api_key.user.full_name
+          expect(parsed_response[model_name]['published']).to be_truthy
+          expect(Time.parse(parsed_response[model_name]['published_on'])).
+            to be_within(10.seconds).of(Time.now)
         end
 
         it "prevents user impersonating anyone or changing dates" do


### PR DESCRIPTION
This also tests deleting not owned data and setting published and published_on flags on create (untested before).