### PR TITLE
Prevents user from seeing another person private data

### DIFF
--- a/app/controllers/plant_lines_controller.rb
+++ b/app/controllers/plant_lines_controller.rb
@@ -2,7 +2,7 @@ class PlantLinesController < ApplicationController
 
   def index
     page = params[:page] || 1
-    plant_lines = PlantLine.filter(params).order(:plant_line_name)
+    plant_lines = PlantLine.filter(params).visible(current_user.try(:id)).order(:plant_line_name)
     render json: {
       results: plant_lines.page(page),
       page: page,

--- a/app/controllers/plant_populations_controller.rb
+++ b/app/controllers/plant_populations_controller.rb
@@ -2,7 +2,7 @@ class PlantPopulationsController < ApplicationController
 
   def index
     page = params[:page] || 1
-    plant_populations = PlantPopulation.filter(params).order(:name)
+    plant_populations = PlantPopulation.filter(params).visible(current_user.try(:id)).order(:name)
     render json: {
       results: plant_populations.page(page),
       page: page,

--- a/app/controllers/plant_varieties_controller.rb
+++ b/app/controllers/plant_varieties_controller.rb
@@ -2,7 +2,7 @@ class PlantVarietiesController < ApplicationController
 
   def index
     page = params[:page] || 1
-    plant_varieties = PlantVariety.filter(params).order(:plant_variety_name)
+    plant_varieties = PlantVariety.filter(params).visible(current_user.try(:id)).order(:plant_variety_name)
     render json: {
       results: plant_varieties.page(page),
       page: page,

--- a/app/controllers/trait_descriptors_controller.rb
+++ b/app/controllers/trait_descriptors_controller.rb
@@ -3,6 +3,7 @@ class TraitDescriptorsController < ApplicationController
   def index
     page = params[:page] || 1
     descriptors = TraitDescriptor.where("descriptor_name ILIKE ?", "%#{params[:search][:descriptor_name]}%")
+    descriptors = descriptors.visible(current_user.try(:id))
     descriptors = descriptors.order(:descriptor_name)
 
     render json: {

--- a/spec/controllers/plant_lines_controller_spec.rb
+++ b/spec/controllers/plant_lines_controller_spec.rb
@@ -10,5 +10,15 @@ RSpec.describe PlantLinesController do
       expect(json['results'].size).to eq 1
       expect(json['results'][0]['plant_line_name']).to eq plns[0]
     end
+
+    it 'filters forbidden results out' do
+      create(:plant_line, user: create(:user), published: false, plant_line_name: 'pln_private')
+      create(:plant_line, plant_line_name: 'pln_public')
+      get :index, format: :json, search: { plant_line_name: 'pln' }
+      expect(response.content_type).to eq 'application/json'
+      json = JSON.parse(response.body)
+      expect(json['results'].size).to eq 1
+      expect(json['results'][0]['plant_line_name']).to eq 'pln_public'
+    end
   end
 end

--- a/spec/controllers/plant_populations_controller_spec.rb
+++ b/spec/controllers/plant_populations_controller_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe PlantPopulationsController do
+  context '#index' do
+    it 'returns search results' do
+      populations = create_list(:plant_population, 2).map(&:name)
+      get :index, format: :json, search: { name: populations[0][1..-2] }
+      expect(response.content_type).to eq 'application/json'
+      json = JSON.parse(response.body)
+      expect(json['results'].size).to eq 1
+      expect(json['results'][0]['name']).to eq populations[0]
+    end
+  end
+
+  it 'filters forbidden results out' do
+    create(:plant_population, user: create(:user), published: false, name: 'ppn_private')
+    create(:plant_population, name: 'ppn_public')
+    get :index, format: :json, search: { name: 'ppn' }
+    expect(response.content_type).to eq 'application/json'
+    json = JSON.parse(response.body)
+    expect(json['results'].size).to eq 1
+    expect(json['results'][0]['name']).to eq 'ppn_public'
+  end
+end

--- a/spec/controllers/plant_varieties_controller_spec.rb
+++ b/spec/controllers/plant_varieties_controller_spec.rb
@@ -11,4 +11,14 @@ RSpec.describe PlantVarietiesController do
       expect(json['results'][0]['plant_variety_name']).to eq varieties[0]
     end
   end
+
+  it 'filters forbidden results out' do
+    create(:plant_variety, user: create(:user), published: false, plant_variety_name: 'pvn_private')
+    create(:plant_variety, plant_variety_name: 'pvn_public')
+    get :index, format: :json, search: { plant_variety_name: 'pvn' }
+    expect(response.content_type).to eq 'application/json'
+    json = JSON.parse(response.body)
+    expect(json['results'].size).to eq 1
+    expect(json['results'][0]['plant_variety_name']).to eq 'pvn_public'
+  end
 end

--- a/spec/controllers/trait_descriptors_controller_spec.rb
+++ b/spec/controllers/trait_descriptors_controller_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe TraitDescriptorsController do
+  context '#index' do
+    it 'returns search results' do
+      descriptors = create_list(:trait_descriptor, 2).map(&:descriptor_name)
+      get :index, format: :json, search: { descriptor_name: descriptors[0][1..-2] }
+      expect(response.content_type).to eq 'application/json'
+      json = JSON.parse(response.body)
+      expect(json['results'].size).to eq 1
+      expect(json['results'][0]['descriptor_name']).to eq descriptors[0]
+    end
+  end
+
+  it 'filters forbidden results out' do
+    create(:trait_descriptor, user: create(:user), published: false, descriptor_name: 'tdn_private')
+    create(:trait_descriptor, descriptor_name: 'tdn_public')
+    get :index, format: :json, search: { descriptor_name: 'tdn' }
+    expect(response.content_type).to eq 'application/json'
+    json = JSON.parse(response.body)
+    expect(json['results'].size).to eq 1
+    expect(json['results'][0]['descriptor_name']).to eq 'tdn_public'
+  end
+end


### PR DESCRIPTION
Fixes #461 

Please note this is not to prevent the user relate her records to someone else's hidden records - this is, actually, not forbidden (one may do that by guessing an id). I just wanted to prevent users seeing (in the autocomplete list) information about other user's hidden records.
