### PR TITLE
Publish state machine fix

### DIFF
--- a/app/assets/stylesheets/partials/_submissions.scss
+++ b/app/assets/stylesheets/partials/_submissions.scss
@@ -19,7 +19,6 @@
     .actions {
       float: right;
       width: 17%;
-      margin-top: 6px;
       text-align: right;
     }
   }

--- a/app/views/submissions/_publishing.html.haml
+++ b/app/views/submissions/_publishing.html.haml
@@ -1,0 +1,6 @@
+- if submission.publishable? && submission.revocable?
+  = confirmable_action("Revoke publication", submission,
+      url: revoke_submission_path(submission), method: :patch)
+- elsif !submission.publishable?
+  = confirmable_action("Publish", submission,
+      url: publish_submission_path(submission), method: :patch, btn_class: "btn-primary")

--- a/app/views/submissions/_submissions_list.html.haml
+++ b/app/views/submissions/_submissions_list.html.haml
@@ -30,10 +30,4 @@
               class: 'btn btn-sm btn-default'
 
         - else
-          - if submission.publishable? && submission.revocable?
-            = confirmable_action("Revoke publication", submission,
-                url: revoke_submission_path(submission), method: :patch)
-
-          - else
-            = confirmable_action("Publish", submission,
-                url: publish_submission_path(submission), method: :patch, btn_class: "btn-primary")
+          = render partial: 'publishing', locals: { submission: submission }

--- a/app/views/submissions/show.html.haml
+++ b/app/views/submissions/show.html.haml
@@ -19,10 +19,4 @@
 
     .col-sm-6.text-right
       - if @submission.finalized?
-        - if @submission.publishable? && @submission.revocable?
-          = confirmable_action("Revoke publication", @submission,
-              url: revoke_submission_path(@submission), method: :patch)
-        - else
-          = confirmable_action("Publish", @submission,
-              url: publish_submission_path(@submission), method: :patch, btn_class: "btn-primary")
-
+        = render partial: 'publishing', locals: { submission: @submission }


### PR DESCRIPTION
One fix is the state machine - I realized one is able to "Publish" already published, and no longer revocable, submission. I also moved both buttons to the _publishing partial.

Another "fix" is strictly visual: when I clicked "no" when asked to confirm "Publish" (or Revoke or Delete, for that matter), it triggered an ugly collapse "animation". Removing the upper margin from the .actions div in the table made the ugly effect disappear. However, now we have the buttons misaligned (changing margin-top to padding-top made no difference). Another solution - http://stackoverflow.com/questions/13119906/turning-off-twitter-bootstrap-navbar-transition-animation - works by making the transition "ultra-fast" (but sometimes still not fast enough). If you have other ideas how to solve that, please commit them here.