### PR TITLE
Some n plus 1 queries

### DIFF
--- a/app/controllers/api/v1/resources_controller.rb
+++ b/app/controllers/api/v1/resources_controller.rb
@@ -18,8 +18,10 @@ class Api::V1::ResourcesController < Api::BaseController
   def index
     filter_params = params[model.name].presence
 
-    resources = Api::Index.new(model).where(filter_params).order(:id)
+    index = Api::Index.new(model)
+    resources = index.where(filter_params).order(:id)
     resources = resources.visible(api_key.user_id) if resources.respond_to? :visible
+    resources = index.load_associations(resources)
     resources = paginate_collection(resources)
     resources = decorate_collection(resources)
 

--- a/app/controllers/trial_scorings_controller.rb
+++ b/app/controllers/trial_scorings_controller.rb
@@ -19,7 +19,6 @@ class TrialScoringsController < ApplicationController
           logger.info 'MISS MISS MISS'
           prepare_grid_data.to_json
         end
-        # grid_data = prepare_grid_data.to_json
         render json: grid_data
       end
     end

--- a/app/controllers/trial_scorings_controller.rb
+++ b/app/controllers/trial_scorings_controller.rb
@@ -19,6 +19,7 @@ class TrialScoringsController < ApplicationController
           logger.info 'MISS MISS MISS'
           prepare_grid_data.to_json
         end
+        # grid_data = prepare_grid_data.to_json
         render json: grid_data
       end
     end

--- a/app/models/plant_trial.rb
+++ b/app/models/plant_trial.rb
@@ -43,10 +43,10 @@ class PlantTrial < ActiveRecord::Base
       where(plant_scoring_units: { plant_trial_id: self.id }).
       where(ts[:user_id].eq(uid).or(ts[:published].eq(true))).
       order('plant_scoring_units.scoring_unit_name asc, trait_descriptors.id asc').
-      group_by(&:plant_scoring_unit)
+      group_by(&:plant_scoring_unit_id)
 
     plant_scoring_units.visible(uid).order('scoring_unit_name asc').map do |unit|
-      scores = all_scores[unit] || []
+      scores = all_scores[unit.id] || []
       [unit.scoring_unit_name] + trait_descriptor_ids.map do |td_id|
         ts = scores.detect{ |s| s.trait_descriptor_id == td_id.to_i}
         ts ? ts.score_value : '-'

--- a/app/services/api/index.rb
+++ b/app/services/api/index.rb
@@ -16,6 +16,14 @@ class Api::Index
     end
   end
 
+  def load_associations(query)
+    if model.klass.respond_to?(:json_options)
+      included_relations = model.klass.json_options[:include]
+      query = query.includes(included_relations).references(included_relations) if included_relations
+    end
+    query
+  end
+
   private
 
   def filterable?

--- a/spec/models/model_spec.rb
+++ b/spec/models/model_spec.rb
@@ -158,6 +158,19 @@ RSpec.describe ActiveRecord::Base do
     end
   end
 
+  context 'when having includes in json_options' do
+    it 'never includes publishable models' do
+      ActiveRecord::Base.send(:subclasses).each do |model|
+        if model.respond_to?(:json_options) && model.json_options[:include].present?
+          model.json_options[:include].each do |included_relation|
+            related_model = model.reflect_on_association(included_relation).klass
+            expect(related_model.column_names).not_to include 'published'
+          end
+        end
+      end
+    end
+  end
+
   it 'includes all numeric columns in table columns' do
     pending
     fail

--- a/spec/models/model_spec.rb
+++ b/spec/models/model_spec.rb
@@ -164,7 +164,7 @@ RSpec.describe ActiveRecord::Base do
         if model.respond_to?(:json_options) && model.json_options[:include].present?
           model.json_options[:include].each do |included_relation|
             related_model = model.reflect_on_association(included_relation).klass
-            expect(related_model.column_names).not_to include 'published'
+            expect(related_model.respond_to?(:published)).to be_falsey
           end
         end
       end

--- a/spec/models/model_spec.rb
+++ b/spec/models/model_spec.rb
@@ -170,9 +170,4 @@ RSpec.describe ActiveRecord::Base do
       end
     end
   end
-
-  it 'includes all numeric columns in table columns' do
-    pending
-    fail
-  end
 end


### PR DESCRIPTION
Fixes #491 
Fixes #473 

Just optimizations, no external behavior should change. Didn't optimize API loading _ids lists of related objects, just the expanded relations - but it's still a considerable time saving.