### PR TITLE
Escape HTML in datatable contents server-side

### DIFF
--- a/app/controllers/data_tables_controller.rb
+++ b/app/controllers/data_tables_controller.rb
@@ -30,7 +30,16 @@ class DataTablesController < ApplicationController
 
   def prepare_grid_data
     objects = model_klass.table_data(params, current_user.try(:id))
+    html_escape_grid_data(objects)
     ApplicationDecorator.decorate(objects).as_grid_data
+  end
+
+  def html_escape_grid_data(objects)
+    objects.each do |object|
+      object.map! do |value|
+        value.is_a?(String) ? ERB::Util.html_escape(value) : value
+      end
+    end
   end
 
   def model_param


### PR DESCRIPTION
Related to #450.

All json data for datatables is html-escaped server-side (before caching). I've browsed through different datatables after applying the fix and I haven't noticed any issues. It is a partial solution to the injection issue, it does not protect from stored injection though.