### PR TITLE
Index database once for each context, not for each example

### DIFF
--- a/spec/models/concerns/searchable_spec.rb
+++ b/spec/models/concerns/searchable_spec.rb
@@ -53,25 +53,24 @@ RSpec.describe Searchable do
     end
   end
 
-  describe "callbacks", :elasticsearch do
+  describe "callbacks" do
     let(:es) { PlantLine.__elasticsearch__.client }
     let(:index) { PlantLine.index_name }
 
-    context "after create" do
-      it "indexes record on creation if published" do
-        plant_line = create(:plant_line, published: true)
+    context "after create", :elasticsearch do
+      let!(:published_plant_line) { create(:plant_line, published: true) }
+      let!(:unpublished_plant_line) { create(:plant_line, published: false) }
 
-        expect(es.exists(id: plant_line.id, index: index)).to be_truthy
+      it "indexes record on creation if published" do
+        expect(es.exists(id: published_plant_line.id, index: index)).to be_truthy
       end
 
       it "does not index record on creation if not published" do
-        plant_line = create(:plant_line, published: false)
-
-        expect(es.exists(id: plant_line.id, index: index)).to be_falsey
+        expect(es.exists(id: unpublished_plant_line.id, index: index)).to be_falsey
       end
     end
 
-    context "after update" do
+    context "after update", :elasticsearch do
       let!(:published_plant_line) { create(:plant_line, published: true) }
       let!(:unpublished_plant_line) { create(:plant_line, published: false) }
 
@@ -88,7 +87,7 @@ RSpec.describe Searchable do
       end
     end
 
-    context "after destroy" do
+    context "after destroy", :elasticsearch do
       let!(:published_plant_line) { create(:plant_line, published: true) }
       let!(:unpublished_plant_line) { create(:plant_line, published: false) }
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -87,7 +87,7 @@ RSpec.configure do |config|
     end
   end
 
-  config.before :each, :elasticsearch do |example|
+  config.before :all, :elasticsearch do |example|
     WebMock.disable_net_connect!(allow_localhost: true)
     searchable_models.each do |model|
       model.import force: true, refresh: true

--- a/spec/services/search_spec.rb
+++ b/spec/services/search_spec.rb
@@ -143,7 +143,7 @@ RSpec.describe Search, :elasticsearch, :dont_clean_db do
   end
 
   after(:all) do
-    DatabaseCleaner.clean
+    DatabaseCleaner.clean_with :truncation
   end
 
   describe "#plant_populations" do


### PR DESCRIPTION
It is pretty wasteful to index the DB for each spec, instead we may do that only once for each context marked with `:elasticsearch`. It may cause strange behaviour though if one forgets how it works.